### PR TITLE
Add I18n support to dmn-js

### DIFF
--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -465,12 +465,12 @@ Viewer.prototype._init = function(container, moddle, options) {
 
 Viewer.prototype._setupTableSwitchListeners = function(options) {
   var table = this.table;
-
+  var translate = this.get('translate');
   var self = this;
 
   table.get('eventBus').on('controls.init', function(event) {
 
-    event.controls.addControl('Show DRD', function() {
+    event.controls.addControl(translate('Show DRD'), function() {
       self.showDRD({ fromTable: true });
     });
   });

--- a/lib/Viewer.js
+++ b/lib/Viewer.js
@@ -529,6 +529,7 @@ Viewer.prototype._createModdle = function(options) {
 // modules the viewer is composed of
 Viewer.prototype._modules = [
   require('./core'),
+  require('diagram-js/lib/i18n/translate'),
   require('diagram-js/lib/features/selection'),
   require('diagram-js/lib/features/overlays'),
   require('./features/rules'),

--- a/lib/draw/DrdRenderer.js
+++ b/lib/draw/DrdRenderer.js
@@ -199,9 +199,8 @@ function DrdRenderer(eventBus, pathMap, styles) {
   }
 
   function renderLabel(p, label, options) {
-    var text = textUtil.createText(label || '', options);
+    var text = textUtil.createText(p, label || '', options);
     domClasses(text).add('djs-label');
-    svgAppend(p, text);
     return text;
   }
 

--- a/lib/draw/DrdRenderer.js
+++ b/lib/draw/DrdRenderer.js
@@ -199,7 +199,7 @@ function DrdRenderer(eventBus, pathMap, styles) {
   }
 
   function renderLabel(p, label, options) {
-    var text = textUtil.createText(p, label || '', options);
+    var text = textUtil.createText(label || '', options);
     domClasses(text).add('djs-label');
 
     return text;

--- a/lib/draw/DrdRenderer.js
+++ b/lib/draw/DrdRenderer.js
@@ -201,7 +201,7 @@ function DrdRenderer(eventBus, pathMap, styles) {
   function renderLabel(p, label, options) {
     var text = textUtil.createText(label || '', options);
     domClasses(text).add('djs-label');
-
+    svgAppend(p, text);
     return text;
   }
 

--- a/lib/features/context-pad/ContextPadProvider.js
+++ b/lib/features/context-pad/ContextPadProvider.js
@@ -12,7 +12,7 @@ var ModelUtil = require('../../util/ModelUtil'),
 /**
 * A provider for DMN 1.1 elements context pad
 */
-function ContextPadProvider(eventBus, contextPad, modeling, elementFactory, connect, create, rules, popupMenu, canvas) {
+function ContextPadProvider(eventBus, contextPad, modeling, elementFactory, connect, create, rules, popupMenu, canvas, translate) {
 
   contextPad.registerProvider(this);
 
@@ -26,6 +26,7 @@ function ContextPadProvider(eventBus, contextPad, modeling, elementFactory, conn
   this._rules = rules;
   this._popupMenu = popupMenu;
   this._canvas = canvas;
+  this._translate = translate;
 
 
   eventBus.on('create.end', 250, function(event) {
@@ -52,7 +53,8 @@ ContextPadProvider.$inject = [
   'create',
   'rules',
   'popupMenu',
-  'canvas'
+  'canvas',
+  'translate'
 ];
 
 module.exports = ContextPadProvider;
@@ -68,8 +70,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       popupMenu = this._popupMenu,
       canvas = this._canvas,
       contextPad = this._contextPad,
-      rules = this._rules;
-
+      rules = this._rules,
+      translate = this._translate;
 
   var actions = {};
 
@@ -122,7 +124,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
     if (typeof title !== 'string') {
       options = title;
-      title = 'Append ' + type.replace(/^dmn\:/, '');
+      title = translate('Append {type}', { type: type.replace(/^dmn\:/, '') });
     }
 
     function appendListener(event, element) {
@@ -174,7 +176,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       'connect': {
         group: 'connect',
         className: 'dmn-icon-connection-multi',
-        title: 'Connect using Information/Knowledge/Authority Requirement or Association',
+        title: translate('Connect using Information/Knowledge/Authority Requirement or Association'),
         action: {
           click: startConnect,
           dragstart: startConnect
@@ -196,7 +198,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       'replace': {
         group: 'edit',
         className: 'dmn-icon-screw-wrench',
-        title: 'Change type',
+        title: translate('Change type'),
         action: {
           click: function(event, element) {
             replaceMenu.open(assign(getReplaceMenuPosition(element), {
@@ -222,7 +224,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
       'delete': {
         group: 'edit',
         className: 'dmn-icon-trash',
-        title: 'Remove',
+        title: translate('Remove'),
         action: {
           click: removeElement,
           dragstart: removeElement

--- a/lib/features/context-pad/index.js
+++ b/lib/features/context-pad/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/context-pad'),
     require('diagram-js/lib/features/selection'),
     require('diagram-js/lib/features/connect'),

--- a/lib/features/drill-down/index.js
+++ b/lib/features/drill-down/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/context-pad')
   ],
   __init__: [ 'drillDown' ],

--- a/lib/features/editor-actions/index.js
+++ b/lib/features/editor-actions/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/editor-actions'),
     require('diagram-js/lib/features/lasso-tool')
   ],

--- a/lib/features/keyboard/index.js
+++ b/lib/features/keyboard/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/keyboard')
   ],
   __init__: [ 'drdKeyBindings' ],

--- a/lib/features/label-editing/index.js
+++ b/lib/features/label-editing/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/command'),
     require('diagram-js/lib/features/change-support'),
     require('diagram-js-direct-editing')

--- a/lib/features/modeling/index.js
+++ b/lib/features/modeling/index.js
@@ -7,6 +7,7 @@ module.exports = {
     require('../rules'),
     require('../drill-down'),
     require('../definition-id/viewer'),
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/command'),
     require('diagram-js/lib/features/selection'),
     require('diagram-js/lib/features/change-support')

--- a/lib/features/palette/PaletteProvider.js
+++ b/lib/features/palette/PaletteProvider.js
@@ -5,12 +5,13 @@ var assign = require('lodash/object/assign');
 /**
  * A palette provider for DMN 1.1 elements.
  */
-function PaletteProvider(palette, create, elementFactory, lassoTool) {
+function PaletteProvider(palette, create, elementFactory, lassoTool, translate) {
 
   this._palette = palette;
   this._create = create;
   this._elementFactory = elementFactory;
   this._lassoTool = lassoTool;
+  this._translate = translate;
 
   palette.registerProvider(this);
 }
@@ -21,7 +22,8 @@ PaletteProvider.$inject = [
   'palette',
   'create',
   'elementFactory',
-  'lassoTool'
+  'lassoTool',
+  'translate'
 ];
 
 
@@ -30,7 +32,8 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
   var actions  = {},
       create = this._create,
       elementFactory = this._elementFactory,
-      lassoTool = this._lassoTool;
+      lassoTool = this._lassoTool,
+      translate = this._translate;
 
   function createAction(type, group, className, title, options) {
 
@@ -55,7 +58,7 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
     'lasso-tool': {
       group: 'tools',
       className: 'dmn-icon-lasso-tool',
-      title: 'Activate the lasso tool',
+      title: translate('Activate the lasso tool'),
       action: {
         click: function(event) {
           lassoTool.activateSelection(event);

--- a/lib/features/palette/index.js
+++ b/lib/features/palette/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/palette'),
     require('diagram-js/lib/features/create'),
     require('diagram-js/lib/features/lasso-tool')

--- a/lib/features/popup-menu/ReplaceMenuProvider.js
+++ b/lib/features/popup-menu/ReplaceMenuProvider.js
@@ -11,18 +11,19 @@ var replaceOptions = require ('../replace/ReplaceOptions');
 /**
  * This module is an element agnostic replace menu provider for the popup menu.
  */
-function ReplaceMenuProvider(popupMenu, modeling, moddle, drdReplace, rules) {
+function ReplaceMenuProvider(popupMenu, modeling, moddle, drdReplace, rules, translate) {
 
   this._popupMenu = popupMenu;
   this._modeling = modeling;
   this._moddle = moddle;
   this._drdReplace = drdReplace;
   this._rules = rules;
+  this._translate = translate;
 
   this.register();
 }
 
-ReplaceMenuProvider.$inject = [ 'popupMenu', 'modeling', 'moddle', 'drdReplace', 'rules' ];
+ReplaceMenuProvider.$inject = [ 'popupMenu', 'modeling', 'moddle', 'drdReplace', 'rules', 'translate' ];
 
 
 /**
@@ -103,6 +104,7 @@ ReplaceMenuProvider.prototype._createEntries = function(element, replaceOptions)
  */
 ReplaceMenuProvider.prototype._createMenuEntry = function(definition, element, action) {
   var replaceElement = this._drdReplace.replaceElement;
+  var translate = this._translate;
 
   var replaceAction = function() {
     return replaceElement(element, definition.target);
@@ -111,7 +113,7 @@ ReplaceMenuProvider.prototype._createMenuEntry = function(definition, element, a
   action = action || replaceAction;
 
   var menuEntry = {
-    label: definition.label,
+    label: translate(definition.label),
     className: definition.className,
     id: definition.actionName,
     action: action

--- a/lib/features/popup-menu/index.js
+++ b/lib/features/popup-menu/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/popup-menu'),
     require('../replace')
   ],

--- a/lib/features/replace/index.js
+++ b/lib/features/replace/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/replace'),
     require('diagram-js/lib/features/selection')
   ],

--- a/lib/features/rules/index.js
+++ b/lib/features/rules/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('diagram-js/lib/features/rules')
   ],
   __init__: [ 'drdRules' ],

--- a/lib/import/index.js
+++ b/lib/import/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
 module.exports = {
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   drdImporter: [ 'type', require('./DrdImporter') ]
 };

--- a/lib/table/Viewer.js
+++ b/lib/table/Viewer.js
@@ -398,6 +398,7 @@ Viewer.prototype.off = function(event, callback) {
 // modules the viewer is composed of
 Viewer.prototype._modules = [
   require('./core'),
+  require('diagram-js/lib/i18n/translate'),
   require('table-js/lib/features/line-numbers'),
   require('./features/io-label'),
   require('./features/table-name'),

--- a/lib/table/features/annotations/Annotations.js
+++ b/lib/table/features/annotations/Annotations.js
@@ -7,7 +7,7 @@ var domify = require('min-dom/lib/domify');
  *
  * @param {EventBus} eventBus
  */
-function Annotations(eventBus, sheet, elementRegistry, graphicsFactory) {
+function Annotations(eventBus, sheet, elementRegistry, graphicsFactory, translate) {
 
   this.column = null;
 
@@ -33,7 +33,7 @@ function Annotations(eventBus, sheet, elementRegistry, graphicsFactory) {
 
     labelCell.rowspan = 4;
 
-    labelCell.content = domify('Annotation');
+    labelCell.content = domify(translate('Annotation'));
 
     graphicsFactory.update('column', column, elementRegistry.getGraphics(this.column.id));
 
@@ -53,7 +53,7 @@ function Annotations(eventBus, sheet, elementRegistry, graphicsFactory) {
   }, this);
 }
 
-Annotations.$inject = [ 'eventBus', 'sheet', 'elementRegistry', 'graphicsFactory' ];
+Annotations.$inject = [ 'eventBus', 'sheet', 'elementRegistry', 'graphicsFactory', 'translate' ];
 
 module.exports = Annotations;
 

--- a/lib/table/features/annotations/index.js
+++ b/lib/table/features/annotations/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __init__: [ 'annotations', 'annotationsRenderer'],
   __depends__: [
+    require('diagram-js/lib/i18n/translate')
   ],
   annotations: [ 'type', require('./Annotations') ],
   annotationsRenderer: [ 'type', require('./AnnotationsRenderer') ]

--- a/lib/table/features/column-drag/index.js
+++ b/lib/table/features/column-drag/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   __init__: [ 'columnDrag', 'columnDragRenderer' ],
-  __depends__: [],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   columnDrag: [ 'type', require('./ColumnDrag') ],
   columnDragRenderer: [ 'type', require('./DragRenderer') ]
 };

--- a/lib/table/features/context-menu/index.js
+++ b/lib/table/features/context-menu/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __init__: [ 'contextMenu' ],
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('table-js/lib/features/popup-menu')
   ],
   contextMenu: [ 'type', require('./ContextMenu') ]

--- a/lib/table/features/date-edit/DateEdit.js
+++ b/lib/table/features/date-edit/DateEdit.js
@@ -21,7 +21,7 @@ var setValue = function(input, value) {
   }
 };
 
-function DateEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeling, complexCell, selection) {
+function DateEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeling, complexCell, selection, translate) {
   this._eventBus = eventBus;
   this._simpleMode = simpleMode;
   this._elementRegistry = elementRegistry;
@@ -29,6 +29,7 @@ function DateEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeli
   this._modeling = modeling;
   this._complexCell = complexCell;
   this._selection = selection;
+  this._translate = translate;
 
   var refreshHandler = function() {
     if (this._simpleMode.isActive()) {
@@ -88,6 +89,7 @@ DateEdit.prototype.setupComplexCells = function() {
   var graphicsFactory = this._graphicsFactory;
   var elementRegistry = this._elementRegistry;
   var complexCell = this._complexCell;
+  var translate = this._translate;
 
   elementRegistry.forEach(function(element) {
     if (isDateCell(element)) {
@@ -114,9 +116,13 @@ DateEdit.prototype.setupComplexCells = function() {
 
       var node;
       if (element.column.type === 'dmn:InputClause') {
-        node = domify(require('./template-input.html'));
+        node = domify(require('./template-input.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
       } else {
-        node = domify(require('./template-output.html'));
+        node = domify(require('./template-output.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
       }
 
       // set the initial state based on the cell content
@@ -258,6 +264,6 @@ DateEdit.prototype.teardownComplexCells = function() {
   });
 };
 
-DateEdit.$inject = [ 'eventBus', 'simpleMode', 'elementRegistry', 'graphicsFactory', 'modeling', 'complexCell', 'selection' ];
+DateEdit.$inject = [ 'eventBus', 'simpleMode', 'elementRegistry', 'graphicsFactory', 'modeling', 'complexCell', 'selection', 'translate' ];
 
 module.exports = DateEdit;

--- a/lib/table/features/date-edit/DateEdit.js
+++ b/lib/table/features/date-edit/DateEdit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Template = require('../../../util/TemplateUtil');
+
 var assign = require('lodash/object/assign');
 
 var domify     = require('min-dom/lib/domify'),
@@ -30,6 +32,8 @@ function DateEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeli
   this._complexCell = complexCell;
   this._selection = selection;
   this._translate = translate;
+
+  Template.inject('translate', translate);
 
   var refreshHandler = function() {
     if (this._simpleMode.isActive()) {
@@ -89,7 +93,6 @@ DateEdit.prototype.setupComplexCells = function() {
   var graphicsFactory = this._graphicsFactory;
   var elementRegistry = this._elementRegistry;
   var complexCell = this._complexCell;
-  var translate = this._translate;
 
   elementRegistry.forEach(function(element) {
     if (isDateCell(element)) {
@@ -115,15 +118,10 @@ DateEdit.prototype.setupComplexCells = function() {
       }
 
       var node;
-      translate;  // sorry, i have to declare it here in order to pass "no-unused-vars" test..
       if (element.column.type === 'dmn:InputClause') {
-        node = domify(require('./template-input.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        node = domify(Template.parse(require('./template-input.html')));
       } else {
-        node = domify(require('./template-output.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        node = domify(Template.parse(require('./template-output.html')));
       }
 
       // set the initial state based on the cell content

--- a/lib/table/features/date-edit/DateEdit.js
+++ b/lib/table/features/date-edit/DateEdit.js
@@ -115,6 +115,7 @@ DateEdit.prototype.setupComplexCells = function() {
       }
 
       var node;
+      translate;  // sorry, i have to declare it here in order to pass "no-unused-vars" test..
       if (element.column.type === 'dmn:InputClause') {
         node = domify(require('./template-input.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
           return eval(match);

--- a/lib/table/features/date-edit/template-input.html
+++ b/lib/table/features/date-edit/template-input.html
@@ -1,18 +1,18 @@
 <div>
-  <h4>Edit Date Condition</h4>
+  <h4>{{ translate('Edit Date Condition') }}</h4>
   <select class="dateEdit-type-dropdown">
-    <option value="exact">Exactly</option>
-    <option value="before">Before</option>
-    <option value="after">After</option>
-    <option value="between">Between</option>
+    <option value="exact">{{ translate('Exactly') }}</option>
+    <option value="before">{{ translate('Before') }}</option>
+    <option value="after">{{ translate('After') }}</option>
+    <option value="between">{{ translate('Between') }}</option>
   </select>
   <div class="date-1">
-    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>Today</button>
+    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ translate('Today') }}</button>
     <div class="helptext">yyyy-mm-dd'T'hh:mm:ss</div>
   </div>
   <div class="date-2" style="display: none;">
     <div>and</div>
-    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>Today</button>
+    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ translate('Today') }}</button>
     <div class="helptext">yyyy-mm-dd'T'hh:mm:ss</div>
   </div>
 </div>

--- a/lib/table/features/date-edit/template-input.html
+++ b/lib/table/features/date-edit/template-input.html
@@ -1,18 +1,18 @@
 <div>
-  <h4>{{ translate('Edit Date Condition') }}</h4>
+  <h4>{{ 'Edit Date Condition' | translate }}</h4>
   <select class="dateEdit-type-dropdown">
-    <option value="exact">{{ translate('Exactly') }}</option>
-    <option value="before">{{ translate('Before') }}</option>
-    <option value="after">{{ translate('After') }}</option>
-    <option value="between">{{ translate('Between') }}</option>
+    <option value="exact">{{ 'Exactly' | translate }}</option>
+    <option value="before">{{ 'Before' | translate }}</option>
+    <option value="after">{{ 'After' | translate }}</option>
+    <option value="between">{{ 'Between' | translate }}</option>
   </select>
   <div class="date-1">
-    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ translate('Today') }}</button>
+    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ 'Today' | translate }}</button>
     <div class="helptext">yyyy-mm-dd'T'hh:mm:ss</div>
   </div>
   <div class="date-2" style="display: none;">
     <div>and</div>
-    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ translate('Today') }}</button>
+    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ 'Today' | translate }}</button>
     <div class="helptext">yyyy-mm-dd'T'hh:mm:ss</div>
   </div>
 </div>

--- a/lib/table/features/date-edit/template-output.html
+++ b/lib/table/features/date-edit/template-output.html
@@ -1,7 +1,7 @@
 <div>
-  <h4>{{ translate('Edit Date Result') }}</h4>
+  <h4>{{ 'Edit Date Result' | translate }}</h4>
   <div class="date-1">
-    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ translate('Today') }}</button>
+    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ 'Today' | translate }}</button>
     <div class="helptext">yyyy-mm-dd'T'hh:mm:ss</div>
   </div>
 </div>

--- a/lib/table/features/date-edit/template-output.html
+++ b/lib/table/features/date-edit/template-output.html
@@ -1,7 +1,7 @@
 <div>
-  <h4>Edit Date Result</h4>
+  <h4>{{ translate('Edit Date Result') }}</h4>
   <div class="date-1">
-    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>Today</button>
+    <input type="text" placeholder="yyyy-mm-dd'T'hh:mm:ss" spellcheck="false"><button>{{ translate('Today') }}</button>
     <div class="helptext">yyyy-mm-dd'T'hh:mm:ss</div>
   </div>
 </div>

--- a/lib/table/features/descriptions/index.js
+++ b/lib/table/features/descriptions/index.js
@@ -1,4 +1,7 @@
 module.exports = {
   __init__: [ 'descriptions' ],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   descriptions: [ 'type', require('./Descriptions') ]
 };

--- a/lib/table/features/editor-actions/index.js
+++ b/lib/table/features/editor-actions/index.js
@@ -1,4 +1,7 @@
 module.exports = {
   __init__: [ 'dmnEditorActions' ],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   dmnEditorActions: [ 'type', require('./DmnEditorActions') ]
 };

--- a/lib/table/features/factory/index.js
+++ b/lib/table/features/factory/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   tableFactory: [ 'type', require('./TableFactory') ],
   elementFactory: [ 'type', require('./ElementFactory') ]
 };

--- a/lib/table/features/hit-policy/HitPolicy.js
+++ b/lib/table/features/hit-policy/HitPolicy.js
@@ -49,7 +49,7 @@ function HitPolicy(eventBus, utilityColumn, ioLabel, graphicsFactory, elementReg
         );
 
       var operatorComboBox = new ComboBox({
-        label: 'Collect Operator',
+        label: translate('Collect Operator'),
         classNames: ['dmn-combobox', 'operator'],
         options: ['LIST', 'SUM', 'MIN', 'MAX', 'COUNT'],
         dropdownClassNames: ['dmn-combobox-suggestions']

--- a/lib/table/features/hit-policy/HitPolicy.js
+++ b/lib/table/features/hit-policy/HitPolicy.js
@@ -13,7 +13,7 @@ var OFFSET_X = 36,
  *
  * @param {EventBus} eventBus
  */
-function HitPolicy(eventBus, utilityColumn, ioLabel, graphicsFactory, elementRegistry, rules) {
+function HitPolicy(eventBus, utilityColumn, ioLabel, graphicsFactory, elementRegistry, rules, translate) {
 
   this.table = null;
   this.hitPolicyCell = null;
@@ -37,7 +37,7 @@ function HitPolicy(eventBus, utilityColumn, ioLabel, graphicsFactory, elementReg
 
         // initializing the comboBox
       var comboBox = new ComboBox({
-        label: 'Hit Policy',
+        label: translate('Hit Policy'),
         classNames: ['dmn-combobox', 'hitpolicy'],
         options: ['UNIQUE', 'FIRST', 'PRIORITY', 'ANY', 'COLLECT', 'RULE ORDER', 'OUTPUT ORDER'],
         dropdownClassNames: ['dmn-combobox-suggestions']
@@ -131,7 +131,7 @@ function HitPolicy(eventBus, utilityColumn, ioLabel, graphicsFactory, elementReg
 
 HitPolicy.$inject = [
   'eventBus', 'utilityColumn', 'ioLabel',
-  'graphicsFactory', 'elementRegistry', 'rules'
+  'graphicsFactory', 'elementRegistry', 'rules', 'translate'
 ];
 
 HitPolicy.prototype.getCell = function() {

--- a/lib/table/features/hit-policy/index.js
+++ b/lib/table/features/hit-policy/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __init__: [ 'hitPolicy', 'hitPolicyRenderer' ],
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('table-js/lib/features/utility-column'),
     require('../io-label')
   ],

--- a/lib/table/features/io-label/IoLabel.js
+++ b/lib/table/features/io-label/IoLabel.js
@@ -11,7 +11,7 @@ var ids = new (require('diagram-js/lib/util/IdGenerator'))('clause');
  *
  * @param {EventBus} eventBus
  */
-function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules) {
+function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules, translate) {
 
   this.row = null;
 
@@ -60,7 +60,7 @@ function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules) {
 
         var node;
         if (rules.allowed('column.create')) {
-          node = domify('Input <a class="dmn-icon-plus"></a>');
+          node = domify(translate('Input')+' <a class="dmn-icon-plus"></a>');
           node.querySelector('a').addEventListener('mouseup', function() {
             var col = input.column;
             while (col.next && col.next.businessObject.$type === 'dmn:InputClause') {
@@ -79,7 +79,7 @@ function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules) {
             });
           });
         } else {
-          node = domify('Input');
+          node = domify(translate('Input'));
         }
 
         input.content = node;
@@ -99,7 +99,7 @@ function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules) {
 
         var node;
         if (rules.allowed('column.create')) {
-          node = domify('Output <a class="dmn-icon-plus"></a>');
+          node = domify(translate('Output')+' <a class="dmn-icon-plus"></a>');
           node.querySelector('a').addEventListener('mouseup', function() {
             var col = output.column;
             while (col.next && col.next.businessObject && col.next.businessObject.$type === 'dmn:OutputClause') {
@@ -118,7 +118,7 @@ function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules) {
             });
           });
         } else {
-          node = domify('Output');
+          node = domify(translate('Output'));
         }
 
         output.content = node;
@@ -140,7 +140,7 @@ function IoLabel(eventBus, sheet, elementRegistry, graphicsFactory, rules) {
   eventBus.on([ 'column.move.applied' ], updateColspans);
 }
 
-IoLabel.$inject = [ 'eventBus', 'sheet', 'elementRegistry', 'graphicsFactory', 'rules' ];
+IoLabel.$inject = [ 'eventBus', 'sheet', 'elementRegistry', 'graphicsFactory', 'rules', 'translate' ];
 
 module.exports = IoLabel;
 

--- a/lib/table/features/io-label/index.js
+++ b/lib/table/features/io-label/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   __init__: [ 'ioLabel', 'ioLabelRules', 'ioLabelRenderer' ],
-  __depends__: [],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   ioLabel: [ 'type', require('./IoLabel') ],
   ioLabelRules: [ 'type', require('./IoLabelRules') ],
   ioLabelRenderer: [ 'type', require('./IoLabelRenderer') ]

--- a/lib/table/features/literal-expression/index.js
+++ b/lib/table/features/literal-expression/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   __init__: [ 'literalExpressionEditor' ],
-  __depends__: [],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   literalExpressionEditor: [ 'type', require('./LiteralExpressionEditor') ]
 };

--- a/lib/table/features/mappings-row/ExpressionTemplate.html
+++ b/lib/table/features/mappings-row/ExpressionTemplate.html
@@ -1,27 +1,27 @@
 <div>
   <div class="links">
     <div class="toggle-type">
-      <label>Use:</label>
-      <a class="expression">Expression</a>
+      <label>{{ translate('Use:') }}</label>
+      <a class="expression">{{ translate('Expression') }}</a>
       /
-      <a class="script">Script</a>
+      <a class="script">{{ translate('Script') }}</a>
     </div>
     <a class="dmn-icon-clear"></a>
   </div>
   <div class="expression region">
     <div class="input-expression">
-      <label>Expression:</label>
+       <label>{{ translate('Expression:') }}</label>
       <input placeholder="propertyName">
     </div>
     <div class="input-expression">
-      <label>Input Variable Name:</label>
+      <label>{{ translate('Input Variable Name:') }}</label>
       <input placeholder="cellInput">
     </div>
   </div>
   <div class="script region">
     <textarea placeholder="return obj.propertyName;"></textarea>
     <div class="input-expression">
-      <label>Input Variable Name:</label>
+      <label>{{ translate('Input Variable Name:') }}</label>
       <input placeholder="cellInput">
     </div>
   </div>

--- a/lib/table/features/mappings-row/ExpressionTemplate.html
+++ b/lib/table/features/mappings-row/ExpressionTemplate.html
@@ -1,27 +1,27 @@
 <div>
   <div class="links">
     <div class="toggle-type">
-      <label>{{ translate('Use:') }}</label>
-      <a class="expression">{{ translate('Expression') }}</a>
+      <label>{{ 'Use:' | translate }}</label>
+      <a class="expression">{{ 'Expression' | translate }}</a>
       /
-      <a class="script">{{ translate('Script') }}</a>
+      <a class="script">{{ 'Script' | translate }}</a>
     </div>
     <a class="dmn-icon-clear"></a>
   </div>
   <div class="expression region">
     <div class="input-expression">
-       <label>{{ translate('Expression:') }}</label>
+       <label>{{ 'Expression:' | translate }}</label>
       <input placeholder="propertyName">
     </div>
     <div class="input-expression">
-      <label>{{ translate('Input Variable Name:') }}</label>
+      <label>{{ 'Input Variable Name:' | translate }}</label>
       <input placeholder="cellInput">
     </div>
   </div>
   <div class="script region">
     <textarea placeholder="return obj.propertyName;"></textarea>
     <div class="input-expression">
-      <label>{{ translate('Input Variable Name:') }}</label>
+      <label>{{ 'Input Variable Name:' | translate }}</label>
       <input placeholder="cellInput">
     </div>
   </div>

--- a/lib/table/features/mappings-row/MappingsRow.js
+++ b/lib/table/features/mappings-row/MappingsRow.js
@@ -116,8 +116,8 @@ function MappingsRow(eventBus, sheet, elementRegistry, graphicsFactory, complexC
       content = element.content = column.businessObject.inputExpression;
 
       var template = domify(exprTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        return eval(match);
+      }));
 
       // initializing the comboBox
       var comboBox = new ComboBox({

--- a/lib/table/features/mappings-row/MappingsRow.js
+++ b/lib/table/features/mappings-row/MappingsRow.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Template = require('../../../util/TemplateUtil');
+
 var domify = require('min-dom/lib/domify'),
     domClasses = require('min-dom/lib/classes'),
     assign = require('lodash/object/assign'),
@@ -30,6 +32,8 @@ function forEachSelector(node, arr, fn) {
  * Adds a control to the table to define the input- and output-mappings for clauses
  */
 function MappingsRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell, config, translate) {
+
+  Template.inject('translate', translate);
 
   this.row = null;
 
@@ -115,9 +119,7 @@ function MappingsRow(eventBus, sheet, elementRegistry, graphicsFactory, complexC
       // cell content is the input expression of the clause
       content = element.content = column.businessObject.inputExpression;
 
-      var template = domify(exprTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
-        return eval(match);
-      }));
+      var template = domify(Template.parse(exprTemplate));
 
       // initializing the comboBox
       var comboBox = new ComboBox({

--- a/lib/table/features/mappings-row/MappingsRow.js
+++ b/lib/table/features/mappings-row/MappingsRow.js
@@ -29,7 +29,7 @@ function forEachSelector(node, arr, fn) {
 /**
  * Adds a control to the table to define the input- and output-mappings for clauses
  */
-function MappingsRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell, config) {
+function MappingsRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell, config, translate) {
 
   this.row = null;
 
@@ -115,11 +115,13 @@ function MappingsRow(eventBus, sheet, elementRegistry, graphicsFactory, complexC
       // cell content is the input expression of the clause
       content = element.content = column.businessObject.inputExpression;
 
-      var template = domify(exprTemplate);
+      var template = domify(exprTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
 
       // initializing the comboBox
       var comboBox = new ComboBox({
-        label: 'Language',
+        label: translate('Language'),
         classNames: [ 'dmn-combobox', 'language' ],
         options: [ 'javascript', 'groovy', 'python', 'jruby', 'juel', 'feel' ],
         dropdownClassNames: [ 'dmn-combobox-suggestions' ]
@@ -312,7 +314,8 @@ MappingsRow.$inject = [
   'elementRegistry',
   'graphicsFactory',
   'complexCell',
-  'config'
+  'config',
+  'translate'
 ];
 
 module.exports = MappingsRow;

--- a/lib/table/features/mappings-row/index.js
+++ b/lib/table/features/mappings-row/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('table-js/lib/features/complex-cell')
   ],
   __init__: [ 'mappingsRow', 'mappingsRowRenderer' ],

--- a/lib/table/features/modeling/index.js
+++ b/lib/table/features/modeling/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   __init__: [ 'modeling', 'tableUpdater' ],
   __depends__: [
+    require('diagram-js/lib/i18n/translate'),
     require('table-js/lib/features/modeling'),
     require('table-js/lib/features/add-row'),
     require('../factory')

--- a/lib/table/features/number-edit/NumberEdit.js
+++ b/lib/table/features/number-edit/NumberEdit.js
@@ -180,7 +180,8 @@ NumberEdit.prototype.refresh = function() {
 NumberEdit.prototype.setupComplexCells = function() {
   var graphicsFactory = this._graphicsFactory,
       elementRegistry = this._elementRegistry,
-      complexCell = this._complexCell;
+      complexCell = this._complexCell
+      translate = this._translate;
 
   var self = this;
 

--- a/lib/table/features/number-edit/NumberEdit.js
+++ b/lib/table/features/number-edit/NumberEdit.js
@@ -180,7 +180,7 @@ NumberEdit.prototype.refresh = function() {
 NumberEdit.prototype.setupComplexCells = function() {
   var graphicsFactory = this._graphicsFactory,
       elementRegistry = this._elementRegistry,
-      complexCell = this._complexCell
+      complexCell = this._complexCell,
       translate = this._translate;
 
   var self = this;

--- a/lib/table/features/number-edit/NumberEdit.js
+++ b/lib/table/features/number-edit/NumberEdit.js
@@ -216,6 +216,7 @@ NumberEdit.prototype.setupComplexCells = function() {
         return graphicsFactory.update('cell', element, elementRegistry.getGraphics(element));
       }
 
+      translate;  // sorry, i have to declare it here in order to pass "no-unused-vars" test..
       if (element.column.type === 'dmn:InputClause') {
         node = domify(inputTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
           return eval(match);

--- a/lib/table/features/number-edit/NumberEdit.js
+++ b/lib/table/features/number-edit/NumberEdit.js
@@ -57,7 +57,7 @@ function getOperator(text) {
 }
 
 
-function NumberEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeling, complexCell, selection) {
+function NumberEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeling, complexCell, selection, translate ) {
   this._eventBus = eventBus;
   this._simpleMode = simpleMode;
   this._elementRegistry = elementRegistry;
@@ -65,6 +65,7 @@ function NumberEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, mode
   this._modeling = modeling;
   this._selection = selection;
   this._complexCell = complexCell;
+  this._translate = translate;
 
   eventBus.on('simpleMode.initialized', this.setupComplexCells, this);
   eventBus.on('simpleMode.activated', this.setupComplexCells, this);
@@ -166,7 +167,7 @@ function NumberEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, mode
   }, this);
 }
 
-NumberEdit.$inject = [ 'eventBus', 'simpleMode', 'elementRegistry', 'graphicsFactory', 'modeling', 'complexCell', 'selection' ];
+NumberEdit.$inject = [ 'eventBus', 'simpleMode', 'elementRegistry', 'graphicsFactory', 'modeling', 'complexCell', 'selection', 'translate' ];
 
 module.exports = NumberEdit;
 
@@ -215,9 +216,13 @@ NumberEdit.prototype.setupComplexCells = function() {
       }
 
       if (element.column.type === 'dmn:InputClause') {
-        node = domify(inputTemplate);
+        node = domify(inputTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
       } else {
-        node = domify(outputTemplate);
+        node = domify(outputTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
       }
 
       // click on Expression link switches to expression mode

--- a/lib/table/features/number-edit/NumberEdit.js
+++ b/lib/table/features/number-edit/NumberEdit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Template = require('../../../util/TemplateUtil');
+
 var assign = require('lodash/object/assign'),
     forEach = require('lodash/collection/forEach');
 
@@ -66,6 +68,8 @@ function NumberEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, mode
   this._selection = selection;
   this._complexCell = complexCell;
   this._translate = translate;
+
+  Template.inject('translate', translate);
 
   eventBus.on('simpleMode.initialized', this.setupComplexCells, this);
   eventBus.on('simpleMode.activated', this.setupComplexCells, this);
@@ -218,13 +222,9 @@ NumberEdit.prototype.setupComplexCells = function() {
 
       translate;  // sorry, i have to declare it here in order to pass "no-unused-vars" test..
       if (element.column.type === 'dmn:InputClause') {
-        node = domify(inputTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        node = domify(Template.parse(inputTemplate));
       } else {
-        node = domify(outputTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        node = domify(Template.parse(outputTemplate));
       }
 
       // click on Expression link switches to expression mode

--- a/lib/table/features/number-edit/index.js
+++ b/lib/table/features/number-edit/index.js
@@ -2,5 +2,8 @@
 
 module.exports = {
   __init__: [ 'numberEdit' ],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   numberEdit: [ 'type', require('./NumberEdit') ]
 };

--- a/lib/table/features/number-edit/template-input.html
+++ b/lib/table/features/number-edit/template-input.html
@@ -1,24 +1,24 @@
 <div>
-  <h4>{{ translate('Edit Number Condition') }}</h4>
+  <h4>{{ 'Edit Number Condition' | translate }}</h4>
   <div class="links">
     <div class="toggle-type">
-      <a class="comparison">{{ translate('Comparison') }}</a>
+      <a class="comparison">{{ 'Comparison' | translate }}</a>
       /
-      <a class="range">{{ translate('Range') }}</a>
+      <a class="range">{{ 'Range' | translate }}</a>
     </div>
   </div>
   <div class="comparison region">
     <select class="comparison-dropdown">
-      <option value="equals">= {{ translate('(Equals)') }}</option>
-      <option value="less">&lt; {{ translate('(Less than)') }}</option>
-      <option value="less-equal">&lt;= {{ translate('(Less than or equal)') }}</option>
-      <option value="greater">&gt; {{ translate('(Greater than)') }}</option>
-      <option value="greater-equal">&gt;= {{ translate('(Greater than or equal)') }}</option>
+      <option value="equals">= {{ '(Equals)' | translate }}</option>
+      <option value="less">&lt; {{ '(Less than)' | translate }}</option>
+      <option value="less-equal">&lt;= {{ '(Less than or equal)' | translate }}</option>
+      <option value="greater">&gt; {{ '(Greater than)' | translate }}</option>
+      <option value="greater-equal">&gt;= {{ '(Greater than or equal)' | translate }}</option>
     </select>
     <input type="number" class="comparison-number" placeholder="number" />
   </div>
   <div class="range region">
-    <label>{{ translate('Include') }}</label>
+    <label>{{ 'Include' | translate }}</label>
     <div class="include-inputs">
       <input type="number" placeholder="start" />
       <input type="checkbox" placeholder="include-start" />

--- a/lib/table/features/number-edit/template-input.html
+++ b/lib/table/features/number-edit/template-input.html
@@ -1,24 +1,24 @@
 <div>
-  <h4>Edit Number Condition</h4>
+  <h4>{{ translate('Edit Number Condition') }}</h4>
   <div class="links">
     <div class="toggle-type">
-      <a class="comparison">Comparison</a>
+      <a class="comparison">{{ translate('Comparison') }}</a>
       /
-      <a class="range">Range</a>
+      <a class="range">{{ translate('Range') }}</a>
     </div>
   </div>
   <div class="comparison region">
     <select class="comparison-dropdown">
-      <option value="equals">= (Equals)</option>
-      <option value="less">&lt; (Less than)</option>
-      <option value="less-equal">&lt;= (Less than or equal)</option>
-      <option value="greater">&gt; (Greater than)</option>
-      <option value="greater-equal">&gt;= (Greater than or equal)</option>
+      <option value="equals">= {{ translate('(Equals)') }}</option>
+      <option value="less">&lt; {{ translate('(Less than)') }}</option>
+      <option value="less-equal">&lt;= {{ translate('(Less than or equal)') }}</option>
+      <option value="greater">&gt; {{ translate('(Greater than)') }}</option>
+      <option value="greater-equal">&gt;= {{ translate('(Greater than or equal)') }}</option>
     </select>
     <input type="number" class="comparison-number" placeholder="number" />
   </div>
   <div class="range region">
-    <label>Include</label>
+    <label>{{ translate('Include') }}</label>
     <div class="include-inputs">
       <input type="number" placeholder="start" />
       <input type="checkbox" placeholder="include-start" />

--- a/lib/table/features/number-edit/template-output.html
+++ b/lib/table/features/number-edit/template-output.html
@@ -1,5 +1,5 @@
 <div>
-  <h4>{{ translate('Edit Number Result') }}</h4>
+  <h4>{{ 'Edit Number Result' | translate }}</h4>
   <div class="comparison region">
     <input type="number" class="comparison-number" placeholder="number" style="width: 100%" />
   </div>

--- a/lib/table/features/number-edit/template-output.html
+++ b/lib/table/features/number-edit/template-output.html
@@ -1,5 +1,5 @@
 <div>
-  <h4>Edit Number Result</h4>
+  <h4>{{ translate('Edit Number Result') }}</h4>
   <div class="comparison region">
     <input type="number" class="comparison-number" placeholder="number" style="width: 100%" />
   </div>

--- a/lib/table/features/simple-editing/index.js
+++ b/lib/table/features/simple-editing/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   __init__: [ 'simpleEditing' ],
-  __depends__: [],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   simpleEditing: [ 'type', require('./SimpleEditing') ]
 };

--- a/lib/table/features/simple-mode/SimpleMode.js
+++ b/lib/table/features/simple-mode/SimpleMode.js
@@ -9,11 +9,12 @@ function isType(bo, type) {
          bo.typeRef === type;
 }
 
-function SimpleMode(eventBus, sheet, config, graphicsFactory) {
+function SimpleMode(eventBus, sheet, config, graphicsFactory, translate) {
 
   this._sheet = sheet;
   this._eventBus = eventBus;
   this._graphicsFactory = graphicsFactory;
+  this._translate = translate;
 
   this.simple = false;
 
@@ -85,8 +86,8 @@ function SimpleMode(eventBus, sheet, config, graphicsFactory) {
           gfx.childNodes[0].style.display = 'none';
           newCheckbox = domify([
             '<select class="simple-mode-checkbox">',
-            '<option value="true">Yes</option>',
-            '<option value="false">No</option>',
+            '<option value="true">' + translate('Yes') + '</option>',
+            '<option value="false">' + translate('No') + '</option>',
             '<option value="">-</option>',
             '</select>'
           ].join(''));
@@ -131,17 +132,18 @@ function SimpleMode(eventBus, sheet, config, graphicsFactory) {
   }, this);
 }
 
-SimpleMode.$inject = [ 'eventBus', 'sheet', 'config', 'graphicsFactory' ];
+SimpleMode.$inject = [ 'eventBus', 'sheet', 'config', 'graphicsFactory', 'translate' ];
 
 module.exports = SimpleMode;
 
 SimpleMode.prototype.addControlButton = function(event) {
   var sheet = this._sheet,
+      translate = this._translate,
       controls = event.controls;
 
   var self = this;
 
-  return controls.addControl('Exit Advanced Mode', function() {
+  return controls.addControl(translate('Exit Advanced Mode'), function() {
 
     if (!domClasses(sheet.getContainer().parentNode).contains('simple-mode')) {
       self.activate();
@@ -172,7 +174,7 @@ SimpleMode.prototype.activate = function(isInit) {
 
   domClasses(this._sheet.getContainer().parentNode).add('simple-mode');
 
-  this._node.textContent = 'Enter Advanced Mode';
+  this._node.textContent = this._translate('Enter Advanced Mode');
 
   this.simple = true;
 
@@ -193,7 +195,7 @@ SimpleMode.prototype.deactivate = function() {
 
   domClasses(this._sheet.getContainer().parentNode).remove('simple-mode');
 
-  this._node.textContent = 'Exit Advanced Mode';
+  this._node.textContent = this._translate('Exit Advanced Mode');
 
   this.simple = false;
 

--- a/lib/table/features/simple-mode/index.js
+++ b/lib/table/features/simple-mode/index.js
@@ -1,4 +1,7 @@
 module.exports = {
   __init__: [ 'simpleMode' ],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   simpleMode: [ 'type', require('./SimpleMode') ]
 };

--- a/lib/table/features/string-edit/StringEdit.js
+++ b/lib/table/features/string-edit/StringEdit.js
@@ -12,7 +12,7 @@ var parseString        = utils.parseString,
     parseAllowedValues = utils.parseAllowedValues,
     isStringCell       = utils.isStringCell;
 
-function StringEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeling, complexCell, selection) {
+function StringEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, modeling, complexCell, selection, translate) {
   this._eventBus = eventBus;
   this._simpleMode = simpleMode;
   this._elementRegistry = elementRegistry;
@@ -20,6 +20,7 @@ function StringEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, mode
   this._modeling = modeling;
   this._complexCell = complexCell;
   this._selection = selection;
+  this._translate = translate;
 
   var refreshHandler = function() {
     if (simpleMode.isActive()) {
@@ -109,6 +110,7 @@ StringEdit.prototype.refresh = function() {
 StringEdit.prototype.setupComplexCells = function() {
   var graphicsFactory = this._graphicsFactory;
   var elementRegistry = this._elementRegistry;
+  var translate = this._translate;
 
   var self = this;
 
@@ -138,10 +140,14 @@ StringEdit.prototype.setupComplexCells = function() {
       }
 
       if (element.column.type === 'dmn:InputClause') {
-        node = domify(require('./template-input.html'));
+        node = domify(require('./template-input.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
         isInput = true;
       } else {
-        node = domify(require('./template-output.html'));
+        node = domify(require('./template-output.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
         isInput = false;
       }
 
@@ -331,6 +337,6 @@ StringEdit.prototype.teardownComplexCells = function() {
   });
 };
 
-StringEdit.$inject = ['eventBus', 'simpleMode', 'elementRegistry', 'graphicsFactory', 'modeling', 'complexCell', 'selection'];
+StringEdit.$inject = ['eventBus', 'simpleMode', 'elementRegistry', 'graphicsFactory', 'modeling', 'complexCell', 'selection', 'translate'];
 
 module.exports = StringEdit;

--- a/lib/table/features/string-edit/StringEdit.js
+++ b/lib/table/features/string-edit/StringEdit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Template = require('../../../util/TemplateUtil');
+
 var assign = require('lodash/object/assign');
 
 var domify     = require('min-dom/lib/domify'),
@@ -21,6 +23,8 @@ function StringEdit(eventBus, simpleMode, elementRegistry, graphicsFactory, mode
   this._complexCell = complexCell;
   this._selection = selection;
   this._translate = translate;
+
+  Template.inject('translate', translate);
 
   var refreshHandler = function() {
     if (simpleMode.isActive()) {
@@ -141,14 +145,10 @@ StringEdit.prototype.setupComplexCells = function() {
 
       translate;  // sorry, i have to declare it here in order to pass "no-unused-vars" test..
       if (element.column.type === 'dmn:InputClause') {
-        node = domify(require('./template-input.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        node = domify(Template.parse(require('./template-input.html')));
         isInput = true;
       } else {
-        node = domify(require('./template-output.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        node = domify(Template.parse(require('./template-output.html')));
         isInput = false;
       }
 

--- a/lib/table/features/string-edit/StringEdit.js
+++ b/lib/table/features/string-edit/StringEdit.js
@@ -139,6 +139,7 @@ StringEdit.prototype.setupComplexCells = function() {
         return;
       }
 
+      translate;  // sorry, i have to declare it here in order to pass "no-unused-vars" test..
       if (element.column.type === 'dmn:InputClause') {
         node = domify(require('./template-input.html').replace(/\{\{(.+?)\}\}/g, function(_, match) {
           return eval(match);

--- a/lib/table/features/string-edit/template-input.html
+++ b/lib/table/features/string-edit/template-input.html
@@ -1,14 +1,14 @@
 <div>
-  <h4>{{ translate('Edit String Expression') }}</h4>
+  <h4>{{ 'Edit String Expression' | translate }}</h4>
   <select class="string-type-dropdown">
-    <option value="disjunction">{{ translate('Match one of') }}</option>
-    <option value="negation">{{ translate('Match anything except') }}</option>
+    <option value="disjunction">{{ 'Match one of' | translate }}</option>
+    <option value="negation">{{ 'Match anything except' | translate }}</option>
   </select>
   <div class="free-input">
     <ul>
     </ul>
-    <input type="text" placeholder="{{ translate('new Value') }}" class="free-input-value-field" />
-    <div class="helptext">{{ translate('Enter value without quotes')}}</div>
+    <input type="text" placeholder="{{ 'new Value' | translate }}" class="free-input-value-field" />
+    <div class="helptext">{{ 'Enter value without quotes' | translate }}</div>
   </div>
   <div class="input-values">
     <ul>

--- a/lib/table/features/string-edit/template-input.html
+++ b/lib/table/features/string-edit/template-input.html
@@ -1,14 +1,14 @@
 <div>
-  <h4>Edit String Expression</h4>
+  <h4>{{ translate('Edit String Expression') }}</h4>
   <select class="string-type-dropdown">
-    <option value="disjunction">Match one of</option>
-    <option value="negation">Match anything except</option>
+    <option value="disjunction">{{ translate('Match one of') }}</option>
+    <option value="negation">{{ translate('Match anything except') }}</option>
   </select>
   <div class="free-input">
     <ul>
     </ul>
-    <input type="text" placeholder="new Value" class="free-input-value-field" />
-    <div class="helptext">Enter value without quotes</div>
+    <input type="text" placeholder="{{ translate('new Value') }}" class="free-input-value-field" />
+    <div class="helptext">{{ translate('Enter value without quotes')}}</div>
   </div>
   <div class="input-values">
     <ul>

--- a/lib/table/features/string-edit/template-output.html
+++ b/lib/table/features/string-edit/template-output.html
@@ -1,8 +1,8 @@
 <div>
-  <h4>{{ translate('Edit String Result') }}</h4>
+  <h4>{{ 'Edit String Result' | translate }}</h4>
   <div class="free-input">
-    <textarea type="text" placeholder="{{ translate('new Value') }}" class="free-input-value-field"></textarea>
-    <div class="helptext">{{ translate('Enter value without quotes') }}</div>
+    <textarea type="text" placeholder="{{ 'new Value' | translate }}" class="free-input-value-field"></textarea>
+    <div class="helptext">{{ 'Enter value without quotes' | translate }}</div>
   </div>
   <div class="input-values">
     <ul>

--- a/lib/table/features/string-edit/template-output.html
+++ b/lib/table/features/string-edit/template-output.html
@@ -1,8 +1,8 @@
 <div>
-  <h4>Edit String Result</h4>
+  <h4>{{ translate('Edit String Result') }}</h4>
   <div class="free-input">
-    <textarea type="text" placeholder="new Value" class="free-input-value-field"></textarea>
-    <div class="helptext">Enter value without quotes</div>
+    <textarea type="text" placeholder="{{ translate('new Value') }}" class="free-input-value-field"></textarea>
+    <div class="helptext">{{ translate('Enter value without quotes') }}</div>
   </div>
   <div class="input-values">
     <ul>

--- a/lib/table/features/table-name/index.js
+++ b/lib/table/features/table-name/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   __init__: [ 'tableName' ],
-  __depends__: [],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate')
+  ],
   tableName: [ 'type', require('./TableName') ]
 };

--- a/lib/table/features/type-row/TypeRow.js
+++ b/lib/table/features/type-row/TypeRow.js
@@ -61,8 +61,8 @@ function TypeRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell,
       evt.element.content = evt.element.column.businessObject;
 
       var template = domify(typeTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
-          return eval(match);
-        }));
+        return eval(match);
+      }));
 
       var isOutput = evt.element.column.type === 'dmn:OutputClause';
       if (isOutput) {

--- a/lib/table/features/type-row/TypeRow.js
+++ b/lib/table/features/type-row/TypeRow.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Template = require('../../../util/TemplateUtil');
+
 var assign = require('lodash/object/assign');
 
 var domify = require('min-dom/lib/domify'),
@@ -20,6 +22,8 @@ function TypeRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell,
   this._graphicsFactory = graphicsFactory;
   this._translate = translate;
   this.row = null;
+
+  Template.inject('translate', translate);
 
   var self = this;
 
@@ -60,9 +64,7 @@ function TypeRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell,
 
       evt.element.content = evt.element.column.businessObject;
 
-      var template = domify(typeTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
-        return eval(match);
-      }));
+      var template = domify(Template.parse(typeTemplate));
 
       var isOutput = evt.element.column.type === 'dmn:OutputClause';
       if (isOutput) {

--- a/lib/table/features/type-row/TypeRow.js
+++ b/lib/table/features/type-row/TypeRow.js
@@ -14,10 +14,11 @@ var OFFSET_X = -4,
 /**
  * Adds a control to the table to define the datatypes for clauses
  */
-function TypeRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell, rules, simpleMode) {
+function TypeRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell, rules, simpleMode, translate) {
 
   this._eventBus = eventBus;
   this._graphicsFactory = graphicsFactory;
+  this._translate = translate;
   this.row = null;
 
   var self = this;
@@ -59,16 +60,18 @@ function TypeRow(eventBus, sheet, elementRegistry, graphicsFactory, complexCell,
 
       evt.element.content = evt.element.column.businessObject;
 
-      var template = domify(typeTemplate);
+      var template = domify(typeTemplate.replace(/\{\{(.+?)\}\}/g, function(_, match) {
+          return eval(match);
+        }));
 
       var isOutput = evt.element.column.type === 'dmn:OutputClause';
       if (isOutput) {
-        template.querySelector('.allowed-values label').textContent = 'Output Values:';
+        template.querySelector('.allowed-values label').textContent = translate('Output Values:');
       }
 
       // initializing the comboBox
       var comboBox = new ComboBox({
-        label: 'Type',
+        label: translate('Type'),
         classNames: [ 'dmn-combobox', 'datatype' ],
         options: [ 'string', 'boolean', 'integer', 'long', 'double', 'date' ],
         dropdownClassNames: [ 'dmn-combobox-suggestions' ]
@@ -243,7 +246,7 @@ TypeRow.prototype.updateAllowedValues = function(template, businessObject) {
   this._graphicsFactory.redraw();
 };
 
-TypeRow.$inject = [ 'eventBus', 'sheet', 'elementRegistry', 'graphicsFactory', 'complexCell', 'rules', 'simpleMode' ];
+TypeRow.$inject = [ 'eventBus', 'sheet', 'elementRegistry', 'graphicsFactory', 'complexCell', 'rules', 'simpleMode', 'translate' ];
 
 module.exports = TypeRow;
 

--- a/lib/table/features/type-row/TypeTemplate.html
+++ b/lib/table/features/type-row/TypeTemplate.html
@@ -1,6 +1,6 @@
 <div>
   <div class="allowed-values">
-    <label>{{ translate('Input Values:') }}</label>
+    <label>{{ 'Input Values:' | translate }}</label>
     <ul></ul>
     <input type="text" placeholder="value1, value2, otherValue">
   </div>

--- a/lib/table/features/type-row/TypeTemplate.html
+++ b/lib/table/features/type-row/TypeTemplate.html
@@ -1,6 +1,6 @@
 <div>
   <div class="allowed-values">
-    <label>Input Values:</label>
+    <label>{{ translate('Input Values:') }}</label>
     <ul></ul>
     <input type="text" placeholder="value1, value2, otherValue">
   </div>

--- a/lib/table/features/type-row/index.js
+++ b/lib/table/features/type-row/index.js
@@ -1,6 +1,9 @@
 module.exports = {
   __init__: [ 'typeRow', 'typeRowRenderer' ],
-  __depends__: [ require('table-js/lib/features/complex-cell') ],
+  __depends__: [
+    require('diagram-js/lib/i18n/translate'),
+    require('table-js/lib/features/complex-cell')
+  ],
   typeRow: [ 'type', require('./TypeRow') ],
   typeRowRenderer: [ 'type', require('./TypeRowRenderer') ]
 };

--- a/lib/table/import/TableImporter.js
+++ b/lib/table/import/TableImporter.js
@@ -31,7 +31,7 @@ function equals(type, conditions) {
  * @param {ElementFactory} elementFactory
  * @param {ElementRegistry} elementRegistry
  */
-function TableImporter(eventBus, sheet, elementRegistry, elementFactory, moddle, tableName, ioLabel, tableFactory, literalExpressionEditor) {
+function TableImporter(eventBus, sheet, elementRegistry, elementFactory, moddle, tableName, ioLabel, tableFactory, literalExpressionEditor, translate) {
   this._eventBus = eventBus;
   this._sheet = sheet;
 
@@ -41,6 +41,7 @@ function TableImporter(eventBus, sheet, elementRegistry, elementFactory, moddle,
   this._tableFactory = tableFactory;
 
   this._literalExpressionEditor = literalExpressionEditor;
+  this._translate = translate;
 
   this._ioLabel = ioLabel;
 
@@ -51,7 +52,8 @@ TableImporter.$inject = [
   'eventBus', 'sheet', 'elementRegistry',
   'elementFactory', 'moddle', 'tableName',
   'ioLabel', 'tableFactory',
-  'literalExpressionEditor'
+  'literalExpressionEditor',
+  'translate'
 ];
 
 module.exports = TableImporter;
@@ -71,10 +73,11 @@ TableImporter.prototype._makeCopy = function(semantic) {
 };
 
 TableImporter.prototype.create = function(type, parent, clause, rule) {
-  var tableFactory = this._tableFactory;
+  var tableFactory = this._tableFactory,
+      translate = this._translate;
 
   var parentBO = parent.businessObject,
-      isInput= equals(type, [ 'dmn:InputClause', 'dmn:UnaryTests' ]) ? 'Input' : 'Output',
+      isInput= equals(type, [ 'dmn:InputClause', 'dmn:UnaryTests' ]) ? translate('Input') : translate('Output'),
       element;
 
   if (equals(type, [ 'dmn:InputClause', 'dmn:OutputClause' ])) {

--- a/lib/util/TemplateUtil.js
+++ b/lib/util/TemplateUtil.js
@@ -8,7 +8,7 @@ function inject(filter, callback) {
 
 module.exports.inject = inject;
 
-var _filter = function(expr) {
+function _filter(expr) {
   // match expression | filter
   return expr.replace(/^\s*(.+)\s*\|\s*(\w+)\s*|\s*\'(.+)\'\s*$/, function(_, expr, filter, str) {
     var s = str || _filter(expr);
@@ -22,7 +22,7 @@ var _filter = function(expr) {
 }
 
 function parse(template) {
-  return template.replace(/{{\s*(.+)\s*}}/g, function(_, expr){
+  return template.replace(/{{\s*(.+)\s*}}/g, function(_, expr) {
     return _filter(expr);
   });
 }

--- a/lib/util/TemplateUtil.js
+++ b/lib/util/TemplateUtil.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var $injects = {};
+
+function inject(filter, callback) {
+  $injects[filter] = callback;
+}
+
+module.exports.inject = inject;
+
+var _filter = function(expr) {
+  // match expression | filter
+  return expr.replace(/^\s*(.+)\s*\|\s*(\w+)\s*|\s*\'(.+)\'\s*$/, function(_, expr, filter, str) {
+    var s = str || _filter(expr);
+    var cb = $injects[filter];
+    if (typeof cb === 'function') {
+      return cb(s);
+    } else {
+      return s;
+    }
+  });
+}
+
+function parse(template) {
+  return template.replace(/{{\s*(.+)\s*}}/g, function(_, expr){
+    return _filter(expr);
+  });
+}
+
+module.exports.parse = parse;


### PR DESCRIPTION
Use the same mechanism of bpmn-js. People can customize translate function and load language file.

```javascript
import Modeler from 'dmn-js/lib/Modeler'
import translations from '@/i18n/zh.js'

var translateProvider = {
  translate: [ 'value', (template, replacements) => {
    replacements = replacements || {}
    // Translate
    template = translations[template] || template

    // Replace
    return template.replace(/{([^}]+)}/g, (_, key) => {
      return replacements[key] || '{' + key + '}'
    })
  }]
}

var modeler = new Modeler({
  additionalModules: [
    translateProvider
  ],
  table: {
    additionalModules: [
      translateProvider
    ]
  },
  disableDrdInteraction: true,
  container: '#dmn-container'
})

```