### PR TITLE
fix(dmn-js): make context-menu lists scrollable

### DIFF
--- a/styles/dmn-clausevalues-setter.less
+++ b/styles/dmn-clausevalues-setter.less
@@ -14,6 +14,10 @@
   .allowed-values {
     max-width: 100%;
     padding: @dmn-vertical-padding @dmn-horizontal-padding;
+    ul {
+      max-height: 108px;
+      overflow-y: auto;
+    }
   }
 
   .ranged-values {

--- a/styles/dmn-string-editor.less
+++ b/styles/dmn-string-editor.less
@@ -30,6 +30,8 @@
   ul {
     list-style: none;
     padding: 0;
+    max-height: 108px;
+    overflow-y: auto;
   }
 
   .free-input {


### PR DESCRIPTION
this commit adds a fixed maximum height of 108 px (enough space for 5 items with drawn checks or 6 items with checkboxes) to the lists in the context-menu when adding and selecting input values and allowed values.

closes #209