### PR TITLE
DRD: Make Decision detail box responsive 

### DIFF
--- a/packages/dmn-js-drd/assets/css/dmn-js-drd.css
+++ b/packages/dmn-js-drd/assets/css/dmn-js-drd.css
@@ -884,7 +884,7 @@
 .dmn-definitions {
   position: absolute;
   top: 20px;
-  left: 80px;
+  left: 20px;
   background-color: #FAFAFA;
   border: solid 1px #CCC;
   border-radius: 2px;
@@ -912,7 +912,10 @@
   border-radius: 2px;
   border: 1px solid #aaaaaa;
 }
-.djs-container.two-column .dmn-definitions {
+.djs-container.with-palette .dmn-definitions {
+  left: 80px;
+}
+.djs-container.with-palette-two-column .dmn-definitions {
   left: 130px;
 }
 .literal-expression-editor {

--- a/packages/dmn-js-drd/lib/Viewer.js
+++ b/packages/dmn-js-drd/lib/Viewer.js
@@ -277,6 +277,8 @@ Viewer.prototype.attachTo = function(parentNode) {
   parentNode.appendChild(container);
 
   this._emit('attach', {});
+
+  this.get('canvas').resized();
 };
 
 /**

--- a/packages/dmn-js-drd/lib/features/definition-properties/PaletteAdapter.js
+++ b/packages/dmn-js-drd/lib/features/definition-properties/PaletteAdapter.js
@@ -1,0 +1,24 @@
+var domClasses = require('min-dom/lib/classes');
+
+
+function PaletteAdapter(eventBus, canvas) {
+
+  function toggleMarker(cls, on) {
+    var container = canvas.getContainer();
+
+    domClasses(container).toggle(cls, on);
+  }
+
+  eventBus.on('palette.create', function() {
+    toggleMarker('with-palette', true);
+  });
+
+  eventBus.on('palette.changed', function(event) {
+    toggleMarker('with-palette-two-column', event.twoColumn);
+  });
+
+}
+
+PaletteAdapter.$inject = [ 'eventBus', 'canvas' ];
+
+module.exports = PaletteAdapter;

--- a/packages/dmn-js-drd/lib/features/definition-properties/modeler.js
+++ b/packages/dmn-js-drd/lib/features/definition-properties/modeler.js
@@ -1,5 +1,9 @@
 module.exports = {
   __depends__: [ ],
-  __init__: [ 'definitionPropertiesEdit' ],
-  definitionPropertiesEdit: [ 'type', require('./DefinitionPropertiesEdit') ]
+  __init__: [
+    'definitionPropertiesEdit',
+    'definitionPropertiesPaletteAdapter'
+  ],
+  definitionPropertiesEdit: [ 'type', require('./DefinitionPropertiesEdit') ],
+  definitionPropertiesPaletteAdapter: [ 'type', require('./PaletteAdapter') ]
 };

--- a/packages/dmn-js-drd/lib/features/definition-properties/viewer.js
+++ b/packages/dmn-js-drd/lib/features/definition-properties/viewer.js
@@ -1,5 +1,9 @@
 module.exports = {
   __depends__: [ ],
-  __init__: [ 'definitionPropertiesView' ],
-  definitionPropertiesView: [ 'type', require('./DefinitionPropertiesView') ]
+  __init__: [
+    'definitionPropertiesView',
+    'definitionPropertiesPaletteAdapter'
+  ],
+  definitionPropertiesView: [ 'type', require('./DefinitionPropertiesView') ],
+  definitionPropertiesPaletteAdapter: [ 'type', require('./PaletteAdapter') ]
 };

--- a/packages/dmn-js-drd/test/spec/features/definition-properties/DefinitionPropertiesSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/definition-properties/DefinitionPropertiesSpec.js
@@ -110,13 +110,18 @@ describe('features/definition-properties', function() {
     // given
     var parent = canvas.getContainer();
 
-    parent.style.height = '600px';
+    var propertiesContainer = definitionPropertiesView._container;
+
+    // assume
+    expect(propertiesContainer.offsetLeft).to.eql(80);
 
     // when
+    parent.style.height = '160px';
+
     canvas.resized();
 
     // then
-    expect(definitionPropertiesView._container.offsetLeft).to.equal(130);
+    expect(propertiesContainer.offsetLeft).to.equal(130);
   }));
 
 


### PR DESCRIPTION
Building on top of https://github.com/bpmn-io/diagram-js/issues/199, this makes decision detail box in DRD view responsive:

* triggers resize on attachTo
* shows detail box at correct position with palette, palette two column and without