### PR TITLE
Make drillDown behaviour event based

### DIFF
--- a/packages/dmn-js-drd/lib/features/drill-down/DrillDown.js
+++ b/packages/dmn-js-drd/lib/features/drill-down/DrillDown.js
@@ -38,8 +38,9 @@ export default class DrillDown {
     this._overlays = overlays;
 
     this._config = config || { enabled: true };
+    this._eventBus = eventBus;
 
-    eventBus.on([ 'drdElement.added', 'shape.added' ], ({ element }) => {
+    this._eventBus.on([ 'drdElement.added', 'shape.added' ], ({ element }) => {
 
       for (let i = 0; i < PROVIDERS.length; i++) {
 
@@ -50,6 +51,13 @@ export default class DrillDown {
         if (editable) {
           this.addOverlay(element, className);
         }
+      }
+    });
+
+    this._eventBus.on('drillDown.click', ({ decision, parent }) => {
+      var view = parent.getView(decision);
+      if (view) {
+        parent.open(view);
       }
     });
   }
@@ -101,14 +109,9 @@ export default class DrillDown {
     }
 
     const overlaysRoot = overlays._overlayRoot;
-
+    const { _eventBus } = this;
     domDelegate.bind(overlaysRoot, '[data-overlay-id="' + id + '"]', 'click', () => {
-
-      var view = parent.getView(element.businessObject);
-
-      if (view) {
-        parent.open(view);
-      }
+      _eventBus.fire('drillDown.click', { decision: element.businessObject, parent });
     });
   }
 


### PR DESCRIPTION
Making the drillDown behaviour event based provides the ability to intercept the event and prevent/modify default  behaviour.
This is intended to close [issue 353](https://github.com/bpmn-io/dmn-js/issues/353).