### PR TITLE
feat(shared): emit saveXML life-cycle events

### DIFF
--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -372,6 +372,44 @@ describe('Manager', function() {
 
     });
 
+
+    it('should emit <saveXML.*> events', function(done) {
+
+      var viewer = new TestViewer();
+
+      var events = [];
+
+      viewer.on([
+        'saveXML.start',
+        'saveXML.serialized',
+        'saveXML.done'
+      ], function(e) {
+        // log event type + event arguments
+        events.push([
+          e.type,
+          Object.keys(e).filter(function(key) {
+            return key !== 'type';
+          })
+        ]);
+      });
+
+      viewer.importXML(diagramXML, function(err) {
+
+        // when
+        viewer.saveXML(function(err) {
+
+          // then
+          expect(events).to.eql([
+            [ 'saveXML.start', [ 'definitions' ] ],
+            [ 'saveXML.serialized', ['error', 'xml' ] ],
+            [ 'saveXML.done', ['error', 'xml' ] ]
+          ]);
+
+          done(err);
+        });
+      });
+    });
+
   });
 
 

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: emit `saveXML` life-cycle events
+
 ## 5.0.0
 
 _Republished `v5.0.0-1` as stable version_.


### PR DESCRIPTION
This adds the life-cycle events for XML export as provided by bpmn-js, too.