### PR TITLE
fix(change-support): update change support on ID update

### DIFF
--- a/packages/dmn-js-decision-table/package.json
+++ b/packages/dmn-js-decision-table/package.json
@@ -33,7 +33,7 @@
     "min-dash": "^3.0.0",
     "min-dom": "^3.0.0",
     "selection-ranges": "^3.0.0",
-    "table-js": "^5.0.2"
+    "table-js": "^5.0.3"
   },
   "babel": {
     "presets": [

--- a/packages/dmn-js-decision-table/src/features/decision-table-properties/components/DecisionTablePropertiesEditorComponent.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-properties/components/DecisionTablePropertiesEditorComponent.js
@@ -62,16 +62,11 @@ export default class DecisionTablePropertiesComponent extends Component {
 
   setDecisionTableId = (id) => {
 
-    var bo = this.getBusinessObject();
-
-    var oldId = bo.id;
+    var oldId = this.getBusinessObject().id;
 
     if (oldId === id) {
       return;
     }
-
-    // re-bind change listeners from oldId to new id
-    this.setupChangeListeners({ bind: id, unbind: oldId });
 
     this.modeling.editDecisionTableId(id);
   }

--- a/packages/dmn-js-decision-table/test/spec/features/decision-table-properties/DecisionTablePropertiesEditorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-table-properties/DecisionTablePropertiesEditorSpec.js
@@ -89,39 +89,60 @@ describe('decision table properties', function() {
     }));
 
 
-    it('should edit ID if valid', inject(function(sheet) {
+    describe('should edit ID', function() {
 
-      // given
-      const id = queryEditor('.decision-table-id', testContainer);
+      it('accept if valid', inject(function(sheet) {
 
-      id.focus();
+        // given
+        const id = queryEditor('.decision-table-id', testContainer);
 
-      // when
-      triggerInputEvent(id, 'bar');
+        id.focus();
 
-      // then
-      const root = sheet.getRoot();
+        // when
+        triggerInputEvent(id, 'bar');
 
-      expect(root.businessObject.$parent.id).to.equal('bar');
-    }));
+        // then
+        const root = sheet.getRoot();
+
+        expect(root.businessObject.$parent.id).to.equal('bar');
+      }));
 
 
-    it('should not edit ID if invalid', inject(function(sheet) {
+      it('undo edit', inject(function(sheet, commandStack) {
 
-      // given
-      const id = queryEditor('.decision-table-id', testContainer);
+        // given
+        const id = queryEditor('.decision-table-id', testContainer);
 
-      id.focus();
+        id.focus();
 
-      // when
-      triggerInputEvent(id, '!foo');
+        triggerInputEvent(id, 'bar');
 
-      // then
-      const root = sheet.getRoot();
+        // when
+        commandStack.undo();
 
-      expect(root.businessObject.$parent.id).to.equal('decision');
-      expect(domClasses(id.parentNode).has('invalid')).to.be.true;
-    }));
+        // then
+        expect(id.textContent).to.equal('decision');
+      }));
+
+
+      it('reject if invalid', inject(function(sheet) {
+
+        // given
+        const id = queryEditor('.decision-table-id', testContainer);
+
+        id.focus();
+
+        // when
+        triggerInputEvent(id, '!foo');
+
+        // then
+        const root = sheet.getRoot();
+
+        expect(root.businessObject.$parent.id).to.equal('decision');
+        expect(domClasses(id.parentNode).has('invalid')).to.be.true;
+      }));
+
+    });
 
   });
 

--- a/packages/dmn-js-literal-expression/src/Viewer.js
+++ b/packages/dmn-js-literal-expression/src/Viewer.js
@@ -134,6 +134,15 @@ export default class Viewer extends BaseViewer {
   }
 
   /**
+   * Returns the currently displayed decision.
+   *
+   * @return {ModdleElement}
+   */
+  getDecision() {
+    return this._decision;
+  }
+
+  /**
    * Attach viewer to given parent node.
    *
    * @param  {Element} parentNode

--- a/packages/dmn-js-literal-expression/src/Viewer.js
+++ b/packages/dmn-js-literal-expression/src/Viewer.js
@@ -9,6 +9,7 @@ import {
   remove as domRemove
 } from 'min-dom';
 
+import CoreModule from './core';
 import DecisionPropertiesModule from './features/decision-properties';
 import LiteralExpressionPropertiesModule from './features/literal-expression-properties';
 import PoweredByModule from './features/powered-by';
@@ -191,6 +192,7 @@ export default class Viewer extends BaseViewer {
 
   static _getModules() {
     return [
+      CoreModule,
       DecisionPropertiesModule,
       LiteralExpressionPropertiesModule,
       PoweredByModule,

--- a/packages/dmn-js-literal-expression/src/core/ElementRegistry.js
+++ b/packages/dmn-js-literal-expression/src/core/ElementRegistry.js
@@ -1,0 +1,39 @@
+/**
+ * A single decision element registry.
+ *
+ * The sole purpose of this service is to provide the necessary API
+ * to serve shared components, i.e. the UpdatePropertiesHandler.
+ */
+export default class ElementRegistry {
+
+  constructor(viewer, eventBus) {
+    this._eventBus = eventBus;
+    this._viewer = viewer;
+  }
+
+  getDecision() {
+    return this._viewer.getDecision();
+  }
+
+  updateId(element, newId) {
+
+    var decision = this.getDecision();
+
+    if (element !== decision) {
+      throw new Error('element !== decision');
+    }
+
+    this._eventBus.fire('element.updateId', {
+      element: element,
+      newId: newId
+    });
+
+    element.id = newId;
+  }
+
+}
+
+ElementRegistry.$inject = [
+  'viewer',
+  'eventBus'
+];

--- a/packages/dmn-js-literal-expression/src/core/index.js
+++ b/packages/dmn-js-literal-expression/src/core/index.js
@@ -1,0 +1,6 @@
+import ElementRegistry from './ElementRegistry';
+
+export default {
+  __init__: [ 'elementRegistry' ],
+  elementRegistry: [ 'type', ElementRegistry ]
+};

--- a/packages/dmn-js-literal-expression/src/features/decision-properties/components/DecisionPropertiesComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/decision-properties/components/DecisionPropertiesComponent.js
@@ -9,7 +9,9 @@ export default class DecisionPropertiesComponent extends Component {
   }
 
   render() {
-    const { name, id } = this._viewer._decision;
+
+    // there is only one single element
+    const { name, id } = this._viewer.getDecision();
 
     return (
       <div className="decision-properties">

--- a/packages/dmn-js-literal-expression/src/features/decision-properties/components/DecisionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/decision-properties/components/DecisionPropertiesEditorComponent.js
@@ -10,28 +10,25 @@ export default class DecisionPropertiesEditorComponent extends Component {
   constructor(props, context) {
     super(props, context);
 
-    const viewer = this._viewer = context.injector.get('viewer');
+    this._viewer = context.injector.get('viewer');
     this._modeling = context.injector.get('modeling');
 
-    this.setDecisionName = this.setDecisionName.bind(this);
-    this.setDecisionId = this.setDecisionId.bind(this);
-    this.onElementsChanged = this.onElementsChanged.bind(this);
-    this.validateId = this.validateId.bind(this);
-
-    const { id } = viewer._decision;
-
-    this.setupChangeListeners({ bind: id });
-  }
-
-  componentWillUnmount() {
-    const { id } = this._viewer._decision;
-
     this.setupChangeListeners({
-      unbind: id
+      bind: this.getDecision().id
     });
   }
 
-  onElementsChanged() {
+  componentWillUnmount() {
+    this.setupChangeListeners({
+      unbind: this.getDecision().id
+    });
+  }
+
+  getDecision() {
+    return this._viewer.getDecision();
+  }
+
+  onElementsChanged = () => {
     this.forceUpdate();
   }
 
@@ -50,29 +47,26 @@ export default class DecisionPropertiesEditorComponent extends Component {
     }
   }
 
-  setDecisionName(name) {
+  setDecisionName = (name) => {
     this._modeling.editDecisionName(name);
   }
 
-  setDecisionId(id) {
-    const oldId = this._viewer._decision.id;
+  setDecisionId = (id) => {
+    const oldId = this.getDecision().id;
 
     if (oldId === id) {
       return;
     }
 
-    // re-bind change listeners from oldId to new id
-    this.setupChangeListeners({ bind: id, unbind: oldId });
-
     this._modeling.editDecisionId(id);
   }
 
-  validateId(id) {
-    return validateId(this._viewer._decision, id);
+  validateId = (id) => {
+    return validateId(this.getDecision(), id);
   }
 
   render() {
-    const { name, id } = this._viewer._decision;
+    const { name, id } = this.getDecision();
 
     return (
       <header className="decision-properties">

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
@@ -9,7 +9,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
   }
 
   render() {
-    const { literalExpression, variable } = this._viewer._decision;
+    const { literalExpression, variable } = this._viewer.getDecision();
 
     return (
       <div className="literal-expression-properties">

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
@@ -48,10 +48,10 @@ export default class LiteralExpressionPropertiesComponent extends Component {
   constructor(props, context) {
     super(props, context);
 
-    const viewer = this._viewer = context.injector.get('viewer');
+    this._viewer = context.injector.get('viewer');
     this._modeling = context.injector.get('modeling');
 
-    const decision = viewer._decision;
+    const decision = this._viewer.getDecision();
 
     this.state = {
       name: decision.variable.name,

--- a/packages/dmn-js-literal-expression/src/features/modeling/Modeling.js
+++ b/packages/dmn-js-literal-expression/src/features/modeling/Modeling.js
@@ -8,10 +8,10 @@ import UpdatePropertiesHandler
 
 export default class Modeling {
 
-  constructor(eventBus, commandStack, viewer) {
-    this._eventBus = eventBus;
+  constructor(commandStack, viewer, eventBus) {
     this._commandStack = commandStack;
     this._viewer = viewer;
+    this._eventBus = eventBus;
 
     eventBus.on('viewer.init', () => {
 
@@ -30,8 +30,12 @@ export default class Modeling {
     };
   }
 
+  getDecision() {
+    return this._viewer.getDecision();
+  }
+
   editDecisionName(name) {
-    const decision = this._viewer._decision;
+    const decision = this.getDecision();
 
     const context = {
       element: decision,
@@ -44,7 +48,7 @@ export default class Modeling {
   }
 
   editDecisionId(id) {
-    const decision = this._viewer._decision;
+    const decision = this.getDecision();
 
     const context = {
       element: decision,
@@ -57,7 +61,7 @@ export default class Modeling {
   }
 
   editLiteralExpressionText(text) {
-    const decision = this._viewer._decision,
+    const decision = this.getDecision(),
           literalExpression = decision.literalExpression;
 
     const context = {
@@ -71,7 +75,7 @@ export default class Modeling {
   }
 
   editExpressionLanguage(expressionLanguage) {
-    const decision = this._viewer._decision,
+    const decision = this.getDecision(),
           literalExpression = decision.literalExpression;
 
     const context = {
@@ -85,7 +89,7 @@ export default class Modeling {
   }
 
   editVariableName(name) {
-    const decision = this._viewer._decision,
+    const decision = this.getDecision(),
           variable = decision.variable;
 
     const context = {
@@ -99,7 +103,7 @@ export default class Modeling {
   }
 
   editVariableType(typeRef) {
-    const decision = this._viewer._decision,
+    const decision = this.getDecision(),
           variable = decision.variable;
 
     const context = {
@@ -113,7 +117,7 @@ export default class Modeling {
   }
 }
 
-Modeling.$inject = [ 'eventBus', 'commandStack', 'viewer' ];
+Modeling.$inject = [ 'commandStack', 'viewer', 'eventBus' ];
 
 
 // helpers //////////////////////

--- a/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaComponent.js
@@ -9,7 +9,7 @@ export default class TextareaComponent extends Component {
   }
 
   render() {
-    const { text } = this._viewer.getDecision();
+    const { text } = this._viewer.getDecision().literalExpression;
 
     return (
       <div className="textarea">

--- a/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaComponent.js
@@ -9,7 +9,7 @@ export default class TextareaComponent extends Component {
   }
 
   render() {
-    const { text } = this._viewer._decision.literalExpression;
+    const { text } = this._viewer.getDecision();
 
     return (
       <div className="textarea">

--- a/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaEditorComponent.js
@@ -8,14 +8,20 @@ export default class TextareaEditorComponent extends Component {
     super(props, context);
 
     this._modeling = context.injector.get('modeling');
-    const viewer = this._viewer = context.injector.get('viewer');
+
+    this._viewer = context.injector.get('viewer');
 
     this.editLiteralExpressionText = this.editLiteralExpressionText.bind(this);
     this.onElementsChanged = this.onElementsChanged.bind(this);
 
-    const { id } = viewer._decision.literalExpression;
+    // there is only one single element
+    const { id } = this.getLiteralExpression();
 
     context.changeSupport.onElementsChanged(id, this.onElementsChanged);
+  }
+
+  getLiteralExpression() {
+    return this._viewer.getDecision().literalExpression;
   }
 
   onElementsChanged() {
@@ -27,7 +33,9 @@ export default class TextareaEditorComponent extends Component {
   }
 
   render() {
-    const { text } = this._viewer._decision.literalExpression;
+
+    // there is only one single element
+    const { text } = this.getLiteralExpression();
 
     return (
       <Editor

--- a/packages/dmn-js-literal-expression/src/features/view-drd/ViewDrd.js
+++ b/packages/dmn-js-literal-expression/src/features/view-drd/ViewDrd.js
@@ -5,7 +5,7 @@ const HIGH_PRIORITY = 1500;
 
 export default class ViewDrd {
 
-  constructor(components, eventBus, injector, viewer) {
+  constructor(components, viewer, eventBus, injector) {
     this._injector = injector;
     this._viewer = viewer;
 
@@ -18,7 +18,8 @@ export default class ViewDrd {
     eventBus.on('showDrd', () => {
       const parent = injector.get('_parent', false);
 
-      const definitions = getDefinitions(viewer._decision);
+      // there is only one single element
+      const definitions = this.getDefinitions();
 
       // open definitions
       const view = parent.getView(definitions);
@@ -34,13 +35,19 @@ export default class ViewDrd {
       return;
     }
 
-    const definitions = getDefinitions(this._viewer._decision);
+    // there is only one single element
+    const definitions = this.getDefinitions();
 
     return !!parent.getView(definitions);
   }
+
+  getDefinitions() {
+    return getDefinitions(this._viewer.getDecision());
+  }
+
 }
 
-ViewDrd.$inject = [ 'components', 'eventBus', 'injector', 'viewer' ];
+ViewDrd.$inject = [ 'components', 'viewer', 'eventBus', 'injector' ];
 
 
 // helpers //////////////////////

--- a/packages/dmn-js-literal-expression/test/spec/ViewerSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/ViewerSpec.js
@@ -4,6 +4,7 @@ import TestContainer from 'mocha-test-container-support';
 
 import {
   bootstrapViewer,
+  inject,
   getLiteralExpression
 } from 'test/TestHelper';
 
@@ -47,6 +48,23 @@ describe('Viewer', function() {
 
   it('should import literal expression', function(done) {
     createViewer(simpleXML, done);
+  });
+
+
+  describe('getDecision', function() {
+
+    beforeEach(bootstrapViewer(simpleXML, { container: testContainer }));
+
+    it('should provide viewed decision', inject(function(viewer) {
+
+      // when
+      var decision = viewer.getDecision();
+
+      // then
+      expect(decision).to.exist;
+      expect(decision.id).to.eql('season');
+    }));
+
   });
 
 

--- a/packages/dmn-js-literal-expression/test/spec/core/ElementRegistrySpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/core/ElementRegistrySpec.js
@@ -1,0 +1,72 @@
+import ElementRegistry from 'src/core/ElementRegistry';
+import EventBus from 'diagram-js/lib/core/EventBus';
+
+/* global sinon */
+const {
+  spy
+} = sinon;
+
+
+describe('core - ElementRegistry', function() {
+
+  var viewer;
+  var elementRegistry;
+  var eventBus;
+
+  var decision;
+
+  beforeEach(function() {
+    eventBus = new EventBus();
+
+    decision = {
+      id: 'foo'
+    };
+
+    viewer = {
+      getDecision() {
+        return decision;
+      }
+    };
+
+    elementRegistry = new ElementRegistry(viewer, eventBus);
+  });
+
+
+  it('should provide decision', function() {
+
+    // assume
+    expect(viewer.getDecision()).to.equal(decision);
+
+    // then
+    expect(elementRegistry.getDecision()).to.equal(decision);
+  });
+
+
+  it('should update decision id', function() {
+
+    // given
+    var updateSpy = spy(function(event) {
+
+      expect(event.element).to.equal(decision);
+      expect(decision.id).to.eql('foo');
+      expect(event.newId).to.eql('bar');
+    });
+
+    eventBus.on('element.updateId', updateSpy);
+
+
+    // assume
+    expect(function() {
+      elementRegistry.updateId({ id: 'other' }, '110');
+    }).to.throw('element !== decision');
+
+    // when
+    elementRegistry.updateId(decision, 'bar');
+
+    // then
+    expect(decision.id).to.eql('bar');
+
+    expect(updateSpy).to.have.been.calledOnce;
+  });
+
+});

--- a/packages/dmn-js-literal-expression/test/spec/features/decision-properties/DecisionPropertiesEditorSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/decision-properties/DecisionPropertiesEditorSpec.js
@@ -11,7 +11,9 @@ import TestContainer from 'mocha-test-container-support';
 import literalExpressionXML from '../../literal-expression.dmn';
 
 import DecisionPropertiesEditorModule from 'src/features/decision-properties/editor';
+
 import ModelingModule from 'src/features/modeling';
+
 
 describe('decision properties editor', function() {
 
@@ -48,7 +50,7 @@ describe('decision properties editor', function() {
     triggerInputEvent(editor, 'foo');
 
     // then
-    expect(viewer._decision.name).to.equal('foo');
+    expect(viewer.getDecision().name).to.equal('foo');
   }));
 
 
@@ -63,7 +65,7 @@ describe('decision properties editor', function() {
     triggerInputEvent(editor, 'foo');
 
     // then
-    expect(viewer._decision.id).to.equal('foo');
+    expect(viewer.getDecision().id).to.equal('foo');
   }));
 
 
@@ -79,7 +81,7 @@ describe('decision properties editor', function() {
     triggerInputEvent(editor, 'foo bar');
 
     // then
-    expect(viewer._decision.id).to.equal('season');
+    expect(viewer.getDecision().id).to.equal('season');
 
     expect(domClasses(decisionId).has('invalid')).to.be.true;
   }));

--- a/packages/dmn-js-literal-expression/test/spec/features/decision-properties/DecisionPropertiesEditorSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/decision-properties/DecisionPropertiesEditorSpec.js
@@ -12,6 +12,7 @@ import literalExpressionXML from '../../literal-expression.dmn';
 
 import DecisionPropertiesEditorModule from 'src/features/decision-properties/editor';
 
+import CoreModule from 'src/core';
 import ModelingModule from 'src/features/modeling';
 
 
@@ -19,6 +20,7 @@ describe('decision properties editor', function() {
 
   beforeEach(bootstrapModeler(literalExpressionXML, {
     modules: [
+      CoreModule,
       DecisionPropertiesEditorModule,
       ModelingModule
     ],

--- a/packages/dmn-js-literal-expression/test/spec/features/decision-properties/DecisionPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/decision-properties/DecisionPropertiesSpec.js
@@ -6,6 +6,7 @@ import TestContainer from 'mocha-test-container-support';
 
 import literalExpressionXML from '../../literal-expression.dmn';
 
+import CoreModule from 'src/core';
 import DecisionPropertiesModule from 'src/features/decision-properties';
 
 
@@ -13,6 +14,7 @@ describe('decision properties', function() {
 
   beforeEach(bootstrapViewer(literalExpressionXML, {
     modules: [
+      CoreModule,
       DecisionPropertiesModule
     ]
   }));

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
@@ -52,7 +52,7 @@ describe('literal expression properties editor', function() {
     triggerInputEvent(input, 'foo');
 
     // then
-    expect(viewer._decision.variable.name).to.equal('foo');
+    expect(viewer.getDecision().variable.name).to.equal('foo');
   }));
 
 
@@ -67,7 +67,7 @@ describe('literal expression properties editor', function() {
     triggerInputEvent(input, 'foo');
 
     // then
-    expect(viewer._decision.variable.typeRef).to.equal('foo');
+    expect(viewer.getDecision().variable.typeRef).to.equal('foo');
   }));
 
 
@@ -80,7 +80,7 @@ describe('literal expression properties editor', function() {
     triggerInputSelectChange(inputSelect, 'boolean', testContainer);
 
     // then
-    expect(viewer._decision.variable.typeRef).to.equal('boolean');
+    expect(viewer.getDecision().variable.typeRef).to.equal('boolean');
   }));
 
 
@@ -97,7 +97,7 @@ describe('literal expression properties editor', function() {
     triggerInputEvent(input, '');
 
     // then
-    expect(viewer._decision.variable.typeRef).to.not.exist;
+    expect(viewer.getDecision().variable.typeRef).to.not.exist;
   }));
 
 
@@ -112,7 +112,7 @@ describe('literal expression properties editor', function() {
     triggerInputEvent(input, 'foo');
 
     // then
-    expect(viewer._decision.literalExpression.expressionLanguage)
+    expect(viewer.getDecision().literalExpression.expressionLanguage)
       .to.equal('foo');
   }));
 
@@ -126,7 +126,7 @@ describe('literal expression properties editor', function() {
     triggerInputSelectChange(inputSelect, 'javascript', testContainer);
 
     // then
-    expect(viewer._decision.literalExpression.expressionLanguage)
+    expect(viewer.getDecision().literalExpression.expressionLanguage)
       .to.equal('javascript');
   }));
 
@@ -144,7 +144,8 @@ describe('literal expression properties editor', function() {
     triggerInputEvent(input, '');
 
     // then
-    expect(viewer._decision.literalExpression.expressionLanguage).to.not.exist;
+    expect(viewer.getDecision().literalExpression.expressionLanguage)
+      .to.not.exist;
   }));
 
 });

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
@@ -16,6 +16,7 @@ import literalExpressionXML from '../../literal-expression.dmn';
 import LiteralExpressionPropertiesEditorModule
   from 'src/features/literal-expression-properties/editor';
 
+import CoreModule from 'src/core';
 import ModelingModule from 'src/features/modeling';
 
 
@@ -23,6 +24,7 @@ describe('literal expression properties editor', function() {
 
   beforeEach(bootstrapModeler(literalExpressionXML, {
     modules: [
+      CoreModule,
       LiteralExpressionPropertiesEditorModule,
       ModelingModule
     ],

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionPropertiesSpec.js
@@ -6,6 +6,7 @@ import TestContainer from 'mocha-test-container-support';
 
 import literalExpressionXML from '../../literal-expression.dmn';
 
+import CoreModule from 'src/core';
 import LiteralExpressionPropertiesModule
   from 'src/features/literal-expression-properties';
 
@@ -14,6 +15,7 @@ describe('literal expression properties', function() {
 
   beforeEach(bootstrapViewer(literalExpressionXML, {
     modules: [
+      CoreModule,
       LiteralExpressionPropertiesModule
     ]
   }));

--- a/packages/dmn-js-literal-expression/test/spec/features/modeling/ModelingSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/modeling/ModelingSpec.js
@@ -20,7 +20,7 @@ describe('Modeling', function() {
     modeling.editDecisionName('foo');
 
     // then
-    expect(viewer._decision.name).to.equal('foo');
+    expect(viewer.getDecision().name).to.equal('foo');
   }));
 
 
@@ -30,7 +30,7 @@ describe('Modeling', function() {
     modeling.editDecisionId('foo');
 
     // then
-    expect(viewer._decision.id).to.equal('foo');
+    expect(viewer.getDecision().id).to.equal('foo');
   }));
 
 
@@ -40,7 +40,7 @@ describe('Modeling', function() {
     modeling.editLiteralExpressionText('foo');
 
     // then
-    expect(viewer._decision.literalExpression.text).to.equal('foo');
+    expect(viewer.getDecision().literalExpression.text).to.equal('foo');
   }));
 
 
@@ -50,7 +50,8 @@ describe('Modeling', function() {
     modeling.editExpressionLanguage('foo');
 
     // then
-    expect(viewer._decision.literalExpression.expressionLanguage).to.equal('foo');
+    expect(viewer.getDecision().literalExpression.expressionLanguage)
+      .to.equal('foo');
   }));
 
 
@@ -60,7 +61,7 @@ describe('Modeling', function() {
     modeling.editVariableName('foo');
 
     // then
-    expect(viewer._decision.variable.name).to.equal('foo');
+    expect(viewer.getDecision().variable.name).to.equal('foo');
   }));
 
 
@@ -70,7 +71,7 @@ describe('Modeling', function() {
     modeling.editVariableType('foo');
 
     // then
-    expect(viewer._decision.variable.typeRef).to.equal('foo');
+    expect(viewer.getDecision().variable.typeRef).to.equal('foo');
   }));
 
 });

--- a/packages/dmn-js-literal-expression/test/spec/features/modeling/ModelingSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/modeling/ModelingSpec.js
@@ -2,6 +2,7 @@ import { bootstrapModeler, inject } from 'test/helper';
 
 import simpleStringEditXML from '../../literal-expression.dmn';
 
+import CoreModule from 'src/core';
 import Modeling from 'src/features/modeling';
 
 
@@ -9,6 +10,7 @@ describe('Modeling', function() {
 
   beforeEach(bootstrapModeler(simpleStringEditXML, {
     modules: [
+      CoreModule,
       Modeling
     ],
   }));

--- a/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaEditorSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaEditorSpec.js
@@ -51,7 +51,7 @@ describe('textarea editor', function() {
     triggerInputEvent(editor, 'foo');
 
     // then
-    expect(viewer._decision.literalExpression.text).to.equal('foo');
+    expect(viewer.getDecision().literalExpression.text).to.equal('foo');
   }));
 
 });

--- a/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaEditorSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaEditorSpec.js
@@ -10,6 +10,7 @@ import TestContainer from 'mocha-test-container-support';
 
 import literalExpressionXML from '../../literal-expression.dmn';
 
+import CoreModule from 'src/core';
 import TextareaEditorModule
   from 'src/features/textarea/editor';
 
@@ -20,6 +21,7 @@ describe('textarea editor', function() {
 
   beforeEach(bootstrapModeler(literalExpressionXML, {
     modules: [
+      CoreModule,
       TextareaEditorModule,
       ModelingModule
     ],

--- a/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaSpec.js
@@ -6,6 +6,7 @@ import TestContainer from 'mocha-test-container-support';
 
 import literalExpressionXML from '../../literal-expression.dmn';
 
+import CoreModule from 'src/core';
 import TextareaModule
   from 'src/features/textarea';
 
@@ -14,6 +15,7 @@ describe('textarea', function() {
 
   beforeEach(bootstrapViewer(literalExpressionXML, {
     modules: [
+      CoreModule,
       TextareaModule
     ]
   }));

--- a/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaSpec.js
@@ -30,7 +30,10 @@ describe('textarea', function() {
   it('should render', function() {
 
     // then
-    expect(domQuery('.textarea', testContainer)).to.exist;
+    const textarea = domQuery('.textarea', testContainer);
+
+    expect(textarea).to.exist;
+    expect(textarea.textContent).to.eql('calendar.getSeason(date)');
   });
 
 });

--- a/packages/dmn-js-shared/package.json
+++ b/packages/dmn-js-shared/package.json
@@ -23,7 +23,7 @@
     "min-dom": "^3.0.0",
     "selection-ranges": "^3.0.0",
     "selection-update": "^0.1.2",
-    "table-js": "^5.0.2"
+    "table-js": "^5.0.3"
   },
   "babel": {
     "presets": [

--- a/packages/dmn-js-shared/src/base/viewer/Viewer.js
+++ b/packages/dmn-js-shared/src/base/viewer/Viewer.js
@@ -3,6 +3,9 @@ import { Injector } from 'didi';
 import core from './core';
 
 
+/**
+ * A base for React-style viewers.
+ */
 export default class Viewer {
 
   constructor(options = {}) {

--- a/packages/dmn-js-shared/src/base/viewer/core/ChangeSupport.js
+++ b/packages/dmn-js-shared/src/base/viewer/core/ChangeSupport.js
@@ -1,4 +1,3 @@
-
 export default class ChangeSupport {
   constructor(eventBus) {
     this._listeners = {};
@@ -7,21 +6,8 @@ export default class ChangeSupport {
       this.elementsChanged(elements);
     });
 
-    eventBus.on('root.remove', context => {
-      const oldRootId = context.root.id;
-
-      if (this._listeners[oldRootId]) {
-
-        eventBus.once('root.add', context => {
-          const newRootId = context.root.id;
-
-          this._listeners[newRootId] = this._listeners[oldRootId];
-
-          delete this._listeners[oldRootId];
-        });
-
-      }
-
+    eventBus.on('element.updateId', ({ element, newId }) => {
+      this.updateId(element.id, newId);
     });
   }
 
@@ -73,6 +59,16 @@ export default class ChangeSupport {
       }
     } else {
       this._listeners[id].length = 0;
+    }
+  }
+
+  updateId(oldId, newId) {
+    if (this._listeners[oldId]) {
+
+      this._listeners[newId] = this._listeners[oldId];
+
+      delete this._listeners[oldId];
+
     }
   }
 }

--- a/packages/dmn-js-shared/src/features/modeling/cmd/UpdatePropertiesHandler.js
+++ b/packages/dmn-js-shared/src/features/modeling/cmd/UpdatePropertiesHandler.js
@@ -16,7 +16,8 @@ const ID = 'id';
  */
 export default class EditPropertiesHandler {
 
-  constructor(moddle) {
+  constructor(elementRegistry, moddle) {
+    this._elementRegistry = elementRegistry;
     this._moddle = moddle;
   }
 
@@ -75,12 +76,6 @@ export default class EditPropertiesHandler {
 
     const ids = this._moddle.ids;
 
-    if (isIdChange(bo, newProps)) {
-      ids.unclaim(bo[ID]);
-
-      ids.claim(newProps[ID], bo);
-    }
-
     // Reduce over all new properties and return
     //
     // {
@@ -118,6 +113,15 @@ export default class EditPropertiesHandler {
         };
       }
 
+      // handle ID change
+      if (key === ID && isIdChange(bo, value)) {
+        ids.unclaim(bo[ID]);
+
+        this._elementRegistry.updateId(bo, value);
+
+        ids.claim(value, bo);
+      }
+
       // handle plain update
       bo.set(key, value);
 
@@ -134,12 +138,12 @@ export default class EditPropertiesHandler {
 
 }
 
-EditPropertiesHandler.$inject = [ 'moddle' ];
+EditPropertiesHandler.$inject = [ 'elementRegistry', 'moddle' ];
 
 // helpers //////////////////////
 
-function isIdChange(properties, element) {
-  return ID in properties && properties[ID] !== element[ID];
+function isIdChange(element, newId) {
+  return element[ID] !== newId;
 }
 
 

--- a/packages/dmn-js-shared/test/spec/base/viewer/TestHelper.js
+++ b/packages/dmn-js-shared/test/spec/base/viewer/TestHelper.js
@@ -1,4 +1,6 @@
-import { forEach, uniqueBy } from 'min-dash';
+import {
+  forEach
+} from 'min-dash';
 
 import TestContainer from 'mocha-test-container-support';
 
@@ -35,11 +37,9 @@ export function bootstrap(options = {}, locals = {}) {
       mockModule[k] = [ 'value', v ];
     });
 
-    actualOpts.modules = uniqueBy(
-      [].concat(
-        options.modules || [],
-        [ mockModule ]
-      )
+    actualOpts.modules = [].concat(
+      options.modules || [],
+      [ mockModule ]
     );
 
     if (BASE_JS) {

--- a/packages/dmn-js-shared/test/spec/base/viewer/core/ChangeSupportSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/viewer/core/ChangeSupportSpec.js
@@ -1,10 +1,20 @@
-import { bootstrap, inject } from 'test/spec/base/viewer/TestHelper';
+import { bootstrap, inject } from '../TestHelper';
+
+import CoreModule from 'src/base/viewer/core';
+
 
 /* global sinon */
 
 describe('ChangeSupport', function() {
 
-  beforeEach(bootstrap());
+  beforeEach(bootstrap({
+    modules: [
+      {
+        elementRegistry: [ 'type', MockRegistry ]
+      },
+      CoreModule
+    ]
+  }));
 
 
   it('should add listener', inject(function(changeSupport) {
@@ -25,7 +35,6 @@ describe('ChangeSupport', function() {
 
 
   it('should remove listener', inject(function(changeSupport) {
-
     // given
     const listener = () => {};
 
@@ -42,7 +51,6 @@ describe('ChangeSupport', function() {
 
 
   it('should remove all listeners', inject(function(changeSupport) {
-
     // given
     changeSupport.onElementsChanged('foo', () => {});
     changeSupport.onElementsChanged('foo', () => {});
@@ -97,4 +105,54 @@ describe('ChangeSupport', function() {
 
   });
 
+
+  describe('update ID', function() {
+
+    it('should update on elements change after updating ID', inject(
+      function(eventBus, elementRegistry, changeSupport) {
+
+        // given
+        const spy = sinon.spy();
+
+        const element = {
+          id: 'foo'
+        };
+
+        changeSupport.onElementsChanged(element.id, spy);
+
+        // when
+        elementRegistry.updateId(element, 'bar');
+
+        eventBus.fire('elements.changed', {
+          elements: [ element ]
+        });
+
+        // then
+        expect(spy).to.have.been.calledOnce;
+      })
+    );
+
+  });
+
 });
+
+
+// helpers /////////////////////
+
+
+/**
+ * Mocked for test purposes; provided by libraries as appropriate.
+ */
+function MockRegistry(eventBus) {
+
+  this.updateId = function(element, id) {
+
+    eventBus.fire('element.updateId', {
+      element: element,
+      newId: id
+    });
+
+    element.id = id;
+  };
+
+}


### PR DESCRIPTION
* add ElementRegistry#updateId method
* UpdatePropertiesHandler calls ElementRegistry#updateId when ID is changing
* ChangeSupport listens for 'element.updateId' event fired by ElementRegistry
* add ElementRegistry to dmn-js-literal-expression to enable ChangeSupport update

Depends on https://github.com/bpmn-io/table-js/issues/19

Closes #367