### PR TITLE
fix(shared/Manager): fire attach event in attachTo

### DIFF
--- a/packages/dmn-js-shared/src/base/Manager.js
+++ b/packages/dmn-js-shared/src/base/Manager.js
@@ -264,6 +264,8 @@ export default class Manager {
     }
 
     parentNode.appendChild(this._container);
+
+    this._emit('attach', {});
   }
 
   detach() {

--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -96,6 +96,28 @@ describe('Manager', function() {
 
     describe('events', function() {
 
+      it('should emit <attach> event', function() {
+
+        // given
+        var container = document.createElement('div');
+        var viewer = new TestViewer();
+
+        var events = [];
+
+        viewer.on('attach', function(event) {
+          // log event type + event arguments
+          events.push(event);
+        });
+
+        // when
+        viewer.attachTo(container);
+
+        // then
+        expect(events).to.have.lengthOf(1);
+
+      });
+
+
       it('should emit <import.*> events', function(done) {
 
         // given


### PR DESCRIPTION
Viewers of each dmn-js library fire attach event
when they are attached to a container. The same is
the case regarding other libraries from the modelling
family, i.e. bpmn-js and cmmn-js. Thus, the change
is rather a fix than a feature since user expects
such event to be fired.