### PR TITLE
chore(shared/Manager): emit detach event

### DIFF
--- a/packages/dmn-js-shared/src/base/Manager.js
+++ b/packages/dmn-js-shared/src/base/Manager.js
@@ -269,6 +269,8 @@ export default class Manager {
   }
 
   detach() {
+    this._emit('detach', {});
+
     domRemove(this._container);
   }
 

--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -114,7 +114,27 @@ describe('Manager', function() {
 
         // then
         expect(events).to.have.lengthOf(1);
+      });
 
+
+      it('should emit <detach> event', function() {
+
+        // given
+        var container = document.createElement('div');
+        var viewer = new TestViewer({ container });
+
+        var events = [];
+
+        viewer.on('detach', function(event) {
+          // log event type + event arguments
+          events.push(event);
+        });
+
+        // when
+        viewer.detach();
+
+        // then
+        expect(events).to.have.lengthOf(1);
       });
 
 

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+## 6.2.0
+
+* `CHORE`: emit `attach` and `detach` events
+
 ## 6.1.0
 
 * `CHORE`: bump to `diagram-js@3`


### PR DESCRIPTION
This adds the `detach` event, mirroring https://github.com/bpmn-io/dmn-js/pull/386.