### PR TITLE
fix(shared/Manager): fix viewers iteration on destroy()

### DIFF
--- a/packages/dmn-js-shared/src/base/Manager.js
+++ b/packages/dmn-js-shared/src/base/Manager.js
@@ -275,7 +275,7 @@ export default class Manager {
   }
 
   destroy() {
-    Object.keys(this._viewers, (viewerId) => {
+    Object.keys(this._viewers).forEach((viewerId) => {
       var viewer = this._viewers[viewerId];
 
       safeExecute(viewer, 'destroy');

--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -367,6 +367,38 @@ describe('Manager', function() {
   });
 
 
+  describe('subviewers', function() {
+
+    var manager = new TestViewer();
+
+
+    it('should destroy subviewers on manager destruction', function(done) {
+      manager.importXML(diagramXML, function(err) {
+        if (err) {
+          return done(err);
+        }
+
+        manager._switchView(manager._views[1]);
+        var destroyEventsFired = 0;
+        Object.keys(manager._viewers).forEach(function(viewerKey) {
+          manager._viewers[viewerKey].on('diagram.destroy', function() {
+            destroyEventsFired++;
+          });
+        });
+
+        // when
+        manager.destroy();
+
+        // then
+        expect(destroyEventsFired).to.eql(2);
+
+        done();
+      });
+    });
+
+  });
+
+
   describe('export', function() {
 
     it('should indicate nothing imported', function(done) {

--- a/packages/dmn-js-shared/test/spec/base/TestView.js
+++ b/packages/dmn-js-shared/test/spec/base/TestView.js
@@ -66,4 +66,8 @@ export default class TestView extends View {
     this._eventBus.fire(...args);
   }
 
+  destroy() {
+    this._eventBus.fire('diagram.destroy');
+  }
+
 }


### PR DESCRIPTION
It looks like someone has made a typo in viewers iteration: missed the iteration itself so individual viewers did not destroy themselves.