### PR TITLE
Add background color to even table rows

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
@@ -128,6 +128,10 @@
   font-family: monospace;
 }
 
+.dmn-decision-table-container .tjs-table tbody tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
 /* end basic table styles */
 
 


### PR DESCRIPTION
Closes #404

Preview (`#f8f8f8`): 

<img width="1028" alt="Screenshot 2019-10-11 at 16 00 12" src="https://user-images.githubusercontent.com/28307541/66657516-3dc69f80-ec40-11e9-95a5-b7a6df337a7a.png">

Alternatively, `#eeeeee`:

<img width="1027" alt="Screenshot 2019-10-11 at 15 53 10" src="https://user-images.githubusercontent.com/28307541/66656974-4ff40e00-ec3f-11e9-8241-3eb33b25c94e.png">

The color can be easily changed. I am open for suggestions.