### PR TITLE
Use source maps in dev

### DIFF
--- a/packages/dmn-js-shared/karma.base.js
+++ b/packages/dmn-js-shared/karma.base.js
@@ -87,7 +87,8 @@ module.exports = function(path) {
             'node_modules',
             path
           ]
-        }
+        },
+        devtool: 'eval-source-map'
       }
     });
   };


### PR DESCRIPTION
This adds source maps to the dev mode. It does not affect the production
code, but makes debugging the tests much easier. The most demanding
devtool was chosen because it's the most useful and still does not seem
to reduce the performance in any significant way.