### PR TITLE
fix(decision-table-head): correctly handle values erasing

### DIFF
--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
@@ -76,7 +76,7 @@ export default class InputCellContextMenu extends Component {
       target = target.inputExpression;
     }
 
-    return (unsaved && unsaved[attr]) || target.get(attr);
+    return unsaved && attr in unsaved ? unsaved[attr] : target.get(attr);
   }
 
   render() {

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputCellContextMenu.js
@@ -49,7 +49,7 @@ export default class OutputCellContextMenu extends Component {
 
     const { unsaved } = this.state;
 
-    return (unsaved && unsaved[attr]) || output.get(attr);
+    return unsaved && attr in unsaved ? unsaved[attr] : output.get(attr);
   }
 
   render() {

--- a/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/DecisionTableHeadEditorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/DecisionTableHeadEditorSpec.js
@@ -1,4 +1,4 @@
-import { bootstrapModeler } from 'test/helper';
+import { bootstrapModeler, inject } from 'test/helper';
 
 import { query as domQuery } from 'min-dom';
 
@@ -14,16 +14,6 @@ import ModelingModule from 'src/features/modeling';
 
 describe('decision-table-head/editor', function() {
 
-  beforeEach(bootstrapModeler(diagramXML, {
-    modules: [
-      CoreModule,
-      DecisionTableHeadModule,
-      DecisionTableHeadEditorModule,
-      ModelingModule
-    ],
-    debounceInput: false
-  }));
-
   let testContainer;
 
   beforeEach(function() {
@@ -31,47 +21,142 @@ describe('decision-table-head/editor', function() {
   });
 
 
-  it('should render output name', function() {
+  describe('rendering', function() {
 
-    // when
-    const nameEl = domQuery('.output-name', testContainer);
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: [
+        CoreModule,
+        DecisionTableHeadModule,
+        DecisionTableHeadEditorModule,
+        ModelingModule
+      ],
+      debounceInput: false
+    }));
 
-    // then
-    expect(nameEl).to.exist;
-    expect(nameEl.textContent).to.eql('reason');
+
+    it('should render output name', function() {
+
+      // when
+      const nameEl = domQuery('.output-name', testContainer);
+
+      // then
+      expect(nameEl).to.exist;
+      expect(nameEl.textContent).to.eql('reason');
+    });
+
+
+    it('should render output label', function() {
+
+      // when
+      const labelEl = domQuery('.output-label', testContainer);
+
+      // then
+      expect(labelEl).to.exist;
+      expect(labelEl.textContent).to.eql('Check Result');
+    });
+
+
+    it('should render input expression', function() {
+
+      // when
+      const expressionEl = domQuery('.input-expression', testContainer);
+
+      // then
+      expect(expressionEl).to.exist;
+      expect(expressionEl.textContent).to.eql('sum');
+    });
+
+
+    it('should render input label', function() {
+
+      // when
+      const labelEl = domQuery('.input-label', testContainer);
+
+      // then
+      expect(labelEl).to.exist;
+      expect(labelEl.textContent).to.eql('Customer Status');
+    });
   });
 
 
-  it('should render output label', function() {
+  describe('updating values', function() {
 
-    // when
-    const labelEl = domQuery('.output-label', testContainer);
+    beforeEach(bootstrapModeler(diagramXML, {
+      modules: [
+        CoreModule,
+        DecisionTableHeadModule,
+        DecisionTableHeadEditorModule,
+        ModelingModule,
+        {
+          debounceInput: [ 'factory', flushableDebounceInputFactory ]
+        }
+      ],
+    }));
 
-    // then
-    expect(labelEl).to.exist;
-    expect(labelEl.textContent).to.eql('Check Result');
+
+    it('should correctly display erased input expression', inject(
+      function(debounceInput) {
+
+        // given
+        const inputCell = domQuery('th[data-col-id="input2"]', testContainer);
+        inputCell.click();
+
+        const input = domQuery('.ref-input-label', testContainer);
+
+        setValue(input, 'to-erase');
+        debounceInput.flush();
+
+        // when
+        setValue(input, '');
+
+        // then
+        expect(input.value).to.eql('');
+      })
+    );
+
+
+    it('should correctly display erased output expression', inject(
+      function(debounceInput) {
+
+        // given
+        const outputCell = domQuery('th[data-col-id="output2"]', testContainer);
+        outputCell.click();
+
+        const input = domQuery('.ref-output-label', testContainer);
+
+        setValue(input, 'to-erase');
+        debounceInput.flush();
+
+        // when
+        setValue(input, '');
+
+        // then
+        expect(input.value).to.eql('');
+      })
+    );
   });
-
-
-  it('should render input expression', function() {
-
-    // when
-    const expressionEl = domQuery('.input-expression', testContainer);
-
-    // then
-    expect(expressionEl).to.exist;
-    expect(expressionEl.textContent).to.eql('sum');
-  });
-
-
-  it('should render input label', function() {
-
-    // when
-    const labelEl = domQuery('.input-label', testContainer);
-
-    // then
-    expect(labelEl).to.exist;
-    expect(labelEl.textContent).to.eql('Customer Status');
-  });
-
 });
+
+
+// helper ////
+function flushableDebounceInputFactory() {
+  return function debounce(fn) {
+    let lastArgs, lastThis;
+
+    debounce.flush = function() {
+      fn.apply(lastThis, lastArgs);
+    };
+
+    return function(...args) {
+      lastArgs = args;
+      lastThis = this;
+    };
+  };
+}
+
+function setValue(element, value) {
+  const event = new Event('input');
+
+  element.value = value;
+  element.dispatchEvent(event);
+}


### PR DESCRIPTION
This fixes a problem of restoring the persisted value when
user erased the text. The unsaved `undefined` value was ignored
as falsy and then the persisted value was inserted into the input.

Related to https://github.com/camunda/camunda-modeler/issues/826