### PR TITLE
Configurable expression languages

### DIFF
--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
@@ -65,18 +65,18 @@ export default class InputCell extends Component {
   }
 
   render() {
-    const input = this.props.input;
+    const { input } = this.props;
 
     const {
-      inputExpression
+      inputExpression, defaultExpressionLanguage
     } = input;
 
     var label = input.get('label');
     var inputVariable = input.get('inputVariable');
 
-    var expressionLanguage = inputExpression.get('expressionLanguage') || 'FEEL';
+    var expressionLanguage = inputExpression.get('expressionLanguage') || defaultExpressionLanguage;
 
-    var showLanguageBadge = !label && expressionLanguage != 'FEEL';
+    var showLanguageBadge = !label && expressionLanguage != defaultExpressionLanguage;
 
     return (
       <th

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
@@ -83,6 +83,8 @@ export default class InputCellContextMenu extends Component {
     return (
       <div className="context-menu-container input-edit">
         <InputEditor
+          defaultExpressionLanguage={ this.getValue('defaultExpressionLanguage') }
+          expressionLanguageOptions={ this.getValue('expressionLanguageOptions') }
           expressionLanguage={ this.getValue('expressionLanguage') }
           inputVariable={ this.getValue('inputVariable') }
           label={ this.getValue('label') }

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
@@ -83,8 +83,8 @@ export default class InputCellContextMenu extends Component {
     return (
       <div className="context-menu-container input-edit">
         <InputEditor
-          defaultExpressionLanguage={ this.getValue('defaultExpressionLanguage') }
-          expressionLanguageOptions={ this.getValue('expressionLanguageOptions') }
+          defaultExpressionLanguage={ this.getValue('defaultInputExpressionLanguage') }
+          expressionLanguageOptions={ this.getValue('inputExpressionLanguageOptions') }
           expressionLanguage={ this.getValue('expressionLanguage') }
           inputVariable={ this.getValue('inputVariable') }
           label={ this.getValue('label') }

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
@@ -20,7 +20,7 @@ export default class InputEditor extends Component {
       event.preventDefault();
       event.stopPropagation();
 
-      this.setExpressionLanguage('FEEL');
+      this.setExpressionLanguage('JUEL');
     };
 
     this.handleValue = (text) => {
@@ -30,10 +30,10 @@ export default class InputEditor extends Component {
       let change = { text };
 
       if (isMultiLine(text) && !expressionLanguage) {
-        change.expressionLanguage = 'FEEL';
+        change.expressionLanguage = 'JUEL';
       }
 
-      if (!isMultiLine(text) && expressionLanguage === 'FEEL') {
+      if (!isMultiLine(text) && expressionLanguage === 'JUEL') {
         change.expressionLanguage = undefined;
       }
 

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
@@ -6,21 +6,23 @@ import ContentEditable from 'dmn-js-shared/lib/components/ContentEditable';
 import Input from 'dmn-js-shared/lib/components/Input';
 import InputSelect from 'dmn-js-shared/lib/components/InputSelect';
 
+const defaultExpressionLanguageOptions = [
+  'FEEL',
+  'JUEL',
+  'JavaScript',
+  'Groovy',
+  'Python'
+];
 
 export default class InputEditor extends Component {
 
   constructor(props, context) {
     super(props, context);
 
+    const { defaultExpressionLanguage } = this.props;
+
     this.setExpressionLanguage = (expressionLanguage) => {
       this.handleChange({ expressionLanguage });
-    };
-
-    this.makeScript = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      this.setExpressionLanguage('JUEL');
     };
 
     this.handleValue = (text) => {
@@ -29,12 +31,8 @@ export default class InputEditor extends Component {
 
       let change = { text };
 
-      if (isMultiLine(text) && !expressionLanguage) {
-        change.expressionLanguage = 'JUEL';
-      }
-
-      if (!isMultiLine(text) && expressionLanguage === 'JUEL') {
-        change.expressionLanguage = undefined;
+      if (!expressionLanguage) {
+        change.expressionLanguage = defaultExpressionLanguage;
       }
 
       this.handleChange(change);
@@ -73,20 +71,15 @@ export default class InputEditor extends Component {
 
     const {
       expressionLanguage,
+      defaultExpressionLanguage,
+      expressionLanguageOptions = defaultExpressionLanguageOptions,
       inputVariable,
       label,
       text
     } = this.props;
 
-    var editScript = expressionLanguage || isMultiLine(text);
-
-    var languageOptions = [
-      !isMultiLine(text) && '',
-      'FEEL',
-      'JUEL',
-      'JavaScript',
-      'Groovy',
-      'Python'
+    const languageOptions = [
+      ...new Set([defaultExpressionLanguage].concat(expressionLanguageOptions))
     ].filter(isString).map(o => ({ label: o, value: o }));
 
     return (
@@ -112,46 +105,24 @@ export default class InputEditor extends Component {
             [
               'ref-text',
               'dms-input',
-              editScript ? 'dms-script-input script-editor' : '',
+              'dms-script-input script-editor',
               'dms-fit-row'
             ].join(' ')
           }
           onInput={ this.handleValue }
           value={ text || '' } />
 
-        {
-          !editScript && (
-            <p className="dms-hint">
-              Enter simple <code>FEEL</code> expression or <a href="#"
-                className="ref-make-script"
-                onClick={ this.makeScript }>
-                  change to script
-              </a>.
-            </p>
-          )
-        }
+        <p className="dms-hint">Enter script.</p>
 
-        {
-          editScript && (
-            <p className="dms-hint">
-              Enter script.
-            </p>
-          )
-        }
+        <p>
+          <label className="dms-label">Expression Language</label>
 
-        {
-          editScript && (
-            <p>
-              <label className="dms-label">Expression Language</label>
-
-              <InputSelect
-                className="ref-language"
-                value={ expressionLanguage || '' }
-                onChange={ this.handleLanguageChange }
-                options={ languageOptions } />
-            </p>
-          )
-        }
+          <InputSelect
+            className="ref-language"
+            value={ expressionLanguage || defaultExpressionLanguage }
+            onChange={ this.handleLanguageChange }
+            options={ languageOptions } />
+        </p>
 
         <p className="dms-fill-row">
           <label className="dms-label">Input Variable</label>
@@ -165,10 +136,4 @@ export default class InputEditor extends Component {
       </div>
     );
   }
-}
-
-
-
-function isMultiLine(text) {
-  return text && text.split(/\n/).length > 1;
 }

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
@@ -6,14 +6,6 @@ import ContentEditable from 'dmn-js-shared/lib/components/ContentEditable';
 import Input from 'dmn-js-shared/lib/components/Input';
 import InputSelect from 'dmn-js-shared/lib/components/InputSelect';
 
-const defaultExpressionLanguageOptions = [
-  'FEEL',
-  'JUEL',
-  'JavaScript',
-  'Groovy',
-  'Python'
-];
-
 export default class InputEditor extends Component {
 
   constructor(props, context) {
@@ -72,7 +64,7 @@ export default class InputEditor extends Component {
     const {
       expressionLanguage,
       defaultExpressionLanguage,
-      expressionLanguageOptions = defaultExpressionLanguageOptions,
+      expressionLanguageOptions,
       inputVariable,
       label,
       text

--- a/packages/dmn-js-decision-table/src/features/expression-language/ExpressionLanguage.js
+++ b/packages/dmn-js-decision-table/src/features/expression-language/ExpressionLanguage.js
@@ -4,25 +4,8 @@ import InputSelect from 'dmn-js-shared/lib/components/InputSelect';
 
 import { isInput } from 'dmn-js-shared/lib/util/ModelUtil';
 
-const INPUT_EXPRESSION_LANGUAGE_OPTIONS = [{
-  label: 'FEEL',
-  value: 'feel'
-}, {
-  label: 'JUEL',
-  value: 'juel'
-}, {
-  label: 'JavaScript',
-  value: 'javascript'
-}, {
-  label: 'Groovy',
-  value: 'groovy'
-}, {
-  label: 'Python',
-  value: 'python'
-}, {
-  label: 'JRuby',
-  value: 'jruby'
-}];
+const DEFAULT_INPUT_EXPRESSION_LANGUAGE_OPTIONS = ['FEEL', 'JUEL', 'JavaScript', 'Groovy', 'Python', 'JRuby'];
+const DEFAULT_HEADER_AND_OUTPUT_EXPRESSION_LANGUAGE_OPTIONS = ['JUEL', 'JavaScript', 'Groovy', 'Python', 'JRuby'];
 
 export default class ExpressionLanguage {
   constructor(components, elementRegistry, modeling) {
@@ -44,8 +27,25 @@ export default class ExpressionLanguage {
           return;
         }
 
+        // this needs to come from somewhere
+        const configOptions = {};
+        const {
+          defaultInputExpressionLanguage = 'FEEL',
+          defaultHeaderAndOutputExpressisonLanguage = 'JUEL',
+          inputExpressionLanguageOptions = DEFAULT_INPUT_EXPRESSION_LANGUAGE_OPTIONS,
+          headerAndOutputExpressionLanguageOptions = DEFAULT_HEADER_AND_OUTPUT_EXPRESSION_LANGUAGE_OPTIONS
+        } = configOptions;
+
+        const elementIsInput = isInput(element.col);
+
         const expressionLanguage = element.businessObject.expressionLanguage
-          || (isInput(element.col) ? 'feel' : 'juel');
+          || (elementIsInput ? defaultInputExpressionLanguage : defaultHeaderAndOutputExpressisonLanguage).toLowerCase();
+
+        const expressionLanguageOptions = (elementIsInput ? inputExpressionLanguageOptions : headerAndOutputExpressionLanguageOptions)
+          .map(label => ({
+            label,
+            value: label.toLowerCase()
+          }));
 
         return (
           <div
@@ -58,7 +58,7 @@ export default class ExpressionLanguage {
             <InputSelect
               className="expression-language"
               onChange={ value => this.onChange(element, value) }
-              options={ INPUT_EXPRESSION_LANGUAGE_OPTIONS }
+              options={ expressionLanguageOptions }
               value={ expressionLanguage } />
 
           </div>


### PR DESCRIPTION
The intention here is to introduce four new configuration options:
1. Setting the default Expression Language for Headers (and Output Cells) -- thereby also fixing the currently wrong default mentioned in #405.
2. Setting the default Expression Language for Input Cells -- just to be consistent with the above and avoid it being hard-coded in various places.
3. Setting the available Expression Language Options for Headers and Output Cells -- thereby allowing to hide unwanted options (e.g. if there is no Groovy or JRuby run-time where the decision table will be evaluated or FEEL just doesn't make sense) and add additional ones if desired.
4. Setting the available Expression Language Options for Input Cells -- same as point 3 but to enable different options (e.g. to only offer FEEL here).

The first two points are effectively #19.
The latter two points were already mentioned in my request from three years ago (for the non-react modeler):
> 7. Limit the available script languages for input expressions (to match the ones we actually provide on the classpath).
- https://forum.bpmn.io/t/customization-options-for-dmn-js-modeler/867

------

Related to #19 
Related to #405 