### PR TITLE
fix(shared/InputSelect): suppress mousedown event on select

### DIFF
--- a/packages/dmn-js-decision-table/package.json
+++ b/packages/dmn-js-decision-table/package.json
@@ -34,6 +34,6 @@
     "min-dash": "^3.0.0",
     "min-dom": "^3.1.1",
     "selection-ranges": "^3.0.2",
-    "table-js": "^6.0.0"
+    "table-js": "^6.0.1"
   }
 }

--- a/packages/dmn-js-decision-table/test/spec/features/hit-policy/HitPolicyEditingSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/hit-policy/HitPolicyEditingSpec.js
@@ -3,7 +3,8 @@ import { bootstrapModeler, inject } from 'test/helper';
 import {
   triggerInputEvent,
   triggerInputSelectChange,
-  triggerClick
+  triggerClick,
+  triggerMouseEvent
 } from 'dmn-js-shared/test/util/EventUtil';
 
 import { query as domQuery } from 'min-dom';
@@ -152,6 +153,27 @@ describe('features/hit-policy - editor', function() {
         // then
         expect(root.businessObject.aggregation).to.not.exist;
       }));
+
+    });
+
+
+    describe('integration', function() {
+
+      it('should not close context menu when select option is chosen', function() {
+
+        // given
+        triggerMouseEvent(inputSelect, 'click');
+
+        const option = domQuery('.option[data-value="COLLECT"]', testContainer);
+
+        // when
+        triggerMouseEvent(option, 'mousedown');
+        triggerMouseEvent(option, 'mouseup');
+        triggerMouseEvent(option, 'click');
+
+        // then
+        expect(domQuery('.hit-policy-edit-operator-select', testContainer)).to.exist;
+      });
 
     });
 

--- a/packages/dmn-js-shared/src/components/InputSelect.js
+++ b/packages/dmn-js-shared/src/components/InputSelect.js
@@ -89,10 +89,15 @@ export default class InputSelect extends Component {
     const container = this.renderer.getContainer();
 
     container.appendChild(this._portalEl);
+
+    // suppress mousedown event propagation to handle click events inside the component
+    this._portalEl.addEventListener('mousedown', stopPropagation);
   }
 
   removePortalEl() {
     if (this._portalEl) {
+      this._portalEl.removeEventListener('mousedown', stopPropagation);
+
       domRemove(this._portalEl);
 
       this._portalEl = null;
@@ -333,3 +338,9 @@ export default class InputSelect extends Component {
 }
 
 InputSelect.$inject = [ 'keyboard', 'renderer' ];
+
+
+// helper ////
+function stopPropagation(event) {
+  event.stopPropagation();
+}

--- a/packages/dmn-js-shared/test/spec/components/InputSelectSpec.js
+++ b/packages/dmn-js-shared/test/spec/components/InputSelectSpec.js
@@ -18,7 +18,8 @@ import {
   triggerClick,
   triggerInputEvent,
   triggerKeyEvent,
-  triggerFocusIn
+  triggerFocusIn,
+  triggerMouseEvent
 } from 'test/util/EventUtil';
 
 import InputSelect from 'src/components/InputSelect';
@@ -361,6 +362,44 @@ describe('components/InputSelect', function() {
 
   });
 
+
+  describe('integration', function() {
+
+    it('should not allow the mousedown events to propagate when selecting option',
+      function() {
+
+        // given
+        const injector = createInjector({
+          keyboard: getKeyboardMock(testContainer),
+          renderer: getRendererMock(testContainer)
+        });
+
+        const spy = sinon.spy();
+        const renderedTree = renderIntoDocument(
+          <DiContainer injector={ injector } onMousedown={ spy }>
+            <InputSelect
+              options={ OPTIONS }
+            />
+          </DiContainer>
+        );
+
+        // when
+        const input = findRenderedDOMElementWithClass(renderedTree, 'dms-input');
+
+        triggerClick(input);
+
+        const option = findRenderedDOMElementWithClass(renderedTree, 'option');
+
+        // when
+        triggerMouseEvent(option, 'mousedown');
+        triggerMouseEvent(option, 'mouseup');
+        triggerMouseEvent(option, 'click');
+
+        // then
+        expect(spy).to.not.have.been.called;
+      }
+    );
+  });
 });
 
 // helpers //////////


### PR DESCRIPTION
This prevents closing context menu when option is selected. 

Closes #421 

Contains https://github.com/bpmn-io/dmn-js/pull/422