### PR TITLE
Make expression languages configurable

### DIFF
--- a/packages/dmn-js-decision-table/src/Editor.js
+++ b/packages/dmn-js-decision-table/src/Editor.js
@@ -12,6 +12,7 @@ import decisionTableHeadEditorModule from './features/decision-table-head/editor
 import dragAndDropModule from './features/drag-and-drop';
 import descriptionModule from './features/description';
 import expressionLanguageModule from './features/expression-language';
+import expressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
 import tableHeadEditorModule from './features/decision-table-head/editor';
 import tablePropertiesEditorModule from './features/decision-table-properties/editor';
 import editorActionsModule from 'table-js/lib/features/editor-actions';
@@ -53,6 +54,7 @@ export default class Editor extends Viewer {
       dragAndDropModule,
       descriptionModule,
       expressionLanguageModule,
+      expressionLanguagesModule,
       keyboardModule,
       tableHeadEditorModule,
       tablePropertiesEditorModule,

--- a/packages/dmn-js-decision-table/src/features/decision-rules/index.js
+++ b/packages/dmn-js-decision-table/src/features/decision-rules/index.js
@@ -1,6 +1,11 @@
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
+
 import DecisionRules from './DecisionRules';
 
 export default {
+  __depends__: [
+    ExpressionLanguagesModule
+  ],
   __init__: [ 'decisionRules' ],
   decisionRules: [ 'type', DecisionRules ]
 };

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
@@ -8,7 +8,6 @@ import {
   ComponentWithSlots
 } from 'dmn-js-shared/lib/components/mixins';
 
-const DEFAULT_EXPRESSION_LANGUAGE = 'JUEL';
 
 export default class InputCell extends Component {
 
@@ -38,6 +37,13 @@ export default class InputCell extends Component {
 
   onElementsChanged = () => {
     this.forceUpdate();
+  }
+
+  isDefaultExpressionLanguage(expressionLanguage) {
+    const expressionLanguages = this.context.injector.get('expressionLanguages');
+    const defaultExpressionLanguage = expressionLanguages.getDefault('inputCell').value;
+
+    return expressionLanguage === defaultExpressionLanguage;
   }
 
   componentWillMount() {
@@ -79,7 +85,7 @@ export default class InputCell extends Component {
 
     var showLanguageBadge = !label &&
       expressionLanguage &&
-      expressionLanguage !== DEFAULT_EXPRESSION_LANGUAGE;
+      this.isDefaultExpressionLanguage(expressionLanguage);
 
     return (
       <th

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
@@ -17,6 +17,8 @@ export default class InputCellContextMenu extends Component {
     inject(this);
 
     this.persistChanges = this.debounceInput(this.persistChanges);
+
+    this._expressionLanguages = context.injector.get('expressionLanguages');
   }
 
   persistChanges = () => {
@@ -80,10 +82,15 @@ export default class InputCellContextMenu extends Component {
   }
 
   render() {
+    const defaultLanguage = this._expressionLanguages.getDefault('inputHeadCell'),
+          expressionLanguages = this._expressionLanguages.getAll();
+
     return (
       <div className="context-menu-container input-edit">
         <InputEditor
           expressionLanguage={ this.getValue('expressionLanguage') }
+          expressionLanguages={ expressionLanguages }
+          defaultExpressionLanguage={ defaultLanguage }
           inputVariable={ this.getValue('inputVariable') }
           label={ this.getValue('label') }
           text={ this.getValue('text') }
@@ -95,7 +102,8 @@ export default class InputCellContextMenu extends Component {
 
 InputCellContextMenu.$inject = [
   'debounceInput',
-  'modeling'
+  'modeling',
+  'injector'
 ];
 
 

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
@@ -1,17 +1,15 @@
 import { Component } from 'inferno';
 
-import { isString } from 'min-dash';
-
 import ContentEditable from 'dmn-js-shared/lib/components/ContentEditable';
 import Input from 'dmn-js-shared/lib/components/Input';
 import InputSelect from 'dmn-js-shared/lib/components/InputSelect';
-
-const DEFAULT_EXPRESSION_LANGUAGE = 'JUEL';
 
 export default class InputEditor extends Component {
 
   constructor(props, context) {
     super(props, context);
+
+    const defaultExpressionLanguage = props.defaultExpressionLanguage.value;
 
     this.setExpressionLanguage = (expressionLanguage) => {
       this.handleChange({ expressionLanguage });
@@ -21,7 +19,7 @@ export default class InputEditor extends Component {
       event.preventDefault();
       event.stopPropagation();
 
-      this.setExpressionLanguage(DEFAULT_EXPRESSION_LANGUAGE);
+      this.setExpressionLanguage(defaultExpressionLanguage);
     };
 
     this.handleValue = (text) => {
@@ -31,10 +29,10 @@ export default class InputEditor extends Component {
       let change = { text };
 
       if (isMultiLine(text) && !expressionLanguage) {
-        change.expressionLanguage = DEFAULT_EXPRESSION_LANGUAGE;
+        change.expressionLanguage = defaultExpressionLanguage;
       }
 
-      if (!isMultiLine(text) && expressionLanguage === DEFAULT_EXPRESSION_LANGUAGE) {
+      if (!isMultiLine(text) && expressionLanguage === defaultExpressionLanguage) {
         change.expressionLanguage = undefined;
       }
 
@@ -73,22 +71,15 @@ export default class InputEditor extends Component {
   render() {
 
     const {
+      defaultExpressionLanguage,
       expressionLanguage,
+      expressionLanguages,
       inputVariable,
       label,
       text
     } = this.props;
 
-    var editScript = expressionLanguage || isMultiLine(text);
-
-    var languageOptions = [
-      !isMultiLine(text) && '',
-      'FEEL',
-      'JUEL',
-      'JavaScript',
-      'Groovy',
-      'Python'
-    ].filter(isString).map(o => ({ label: o, value: o }));
+    const editScript = expressionLanguage || isMultiLine(text);
 
     return (
       <div className="dms-container ref-input-editor">
@@ -123,7 +114,7 @@ export default class InputEditor extends Component {
         {
           !editScript && (
             <p className="dms-hint">
-              Enter simple <code>{ DEFAULT_EXPRESSION_LANGUAGE }</code> expression
+              Enter simple <code>{ defaultExpressionLanguage.label }</code> expression
               or <button type="button"
                 className="ref-make-script"
                 onClick={ this.makeScript }>
@@ -150,7 +141,7 @@ export default class InputEditor extends Component {
                 className="ref-language"
                 value={ expressionLanguage || '' }
                 onChange={ this.handleLanguageChange }
-                options={ languageOptions } />
+                options={ expressionLanguages } />
             </p>
           )
         }

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/index.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/index.js
@@ -1,5 +1,6 @@
 import ContextMenu from 'table-js/lib/features/context-menu';
 import DebounceInput from 'dmn-js-shared/lib/features/debounce-input';
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
 
 import OutputEditingProvider from './OutputEditingProvider';
 import InputEditingProvider from './InputEditingProvider';
@@ -15,6 +16,7 @@ export default {
     AllowedValuesEditing,
     ContextMenu,
     DebounceInput,
+    ExpressionLanguagesModule,
     TypeRefEditing
   ],
   __init__: [

--- a/packages/dmn-js-decision-table/src/features/expression-language/ExpressionLanguage.js
+++ b/packages/dmn-js-decision-table/src/features/expression-language/ExpressionLanguage.js
@@ -4,28 +4,9 @@ import InputSelect from 'dmn-js-shared/lib/components/InputSelect';
 
 import { isInput } from 'dmn-js-shared/lib/util/ModelUtil';
 
-const INPUT_EXPRESSION_LANGUAGE_OPTIONS = [{
-  label: 'FEEL',
-  value: 'feel'
-}, {
-  label: 'JUEL',
-  value: 'juel'
-}, {
-  label: 'JavaScript',
-  value: 'javascript'
-}, {
-  label: 'Groovy',
-  value: 'groovy'
-}, {
-  label: 'Python',
-  value: 'python'
-}, {
-  label: 'JRuby',
-  value: 'jruby'
-}];
 
 export default class ExpressionLanguage {
-  constructor(components, elementRegistry, modeling) {
+  constructor(components, elementRegistry, modeling, expressionLanguages) {
     this._modeling = modeling;
 
     components.onGetComponent('context-menu-cell-additional', (context = {}) => {
@@ -45,7 +26,9 @@ export default class ExpressionLanguage {
         }
 
         const expressionLanguage = element.businessObject.expressionLanguage
-          || (isInput(element.col) ? 'feel' : 'juel');
+          || expressionLanguages.getDefault(isInput(element.col) ? 'inputCell' : 'outputCell').value;
+
+        const options = expressionLanguages.getAll();
 
         return (
           <div
@@ -58,7 +41,7 @@ export default class ExpressionLanguage {
             <InputSelect
               className="expression-language"
               onChange={ value => this.onChange(element, value) }
-              options={ INPUT_EXPRESSION_LANGUAGE_OPTIONS }
+              options={ options }
               value={ expressionLanguage } />
 
           </div>
@@ -73,4 +56,4 @@ export default class ExpressionLanguage {
   }
 }
 
-ExpressionLanguage.$inject = [ 'components', 'elementRegistry', 'modeling' ];
+ExpressionLanguage.$inject = [ 'components', 'elementRegistry', 'modeling', 'expressionLanguages' ];

--- a/packages/dmn-js-decision-table/src/features/expression-language/index.js
+++ b/packages/dmn-js-decision-table/src/features/expression-language/index.js
@@ -1,6 +1,11 @@
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
+
 import ExpressionLanguage from './ExpressionLanguage';
 
 export default {
+  __depends__: [
+    ExpressionLanguagesModule
+  ],
   __init__: [ 'expressionLanguage' ],
   expressionLanguage: [ 'type', ExpressionLanguage ]
 };

--- a/packages/dmn-js-decision-table/src/features/simple-mode/components/SimpleModeButtonComponent.js
+++ b/packages/dmn-js-decision-table/src/features/simple-mode/components/SimpleModeButtonComponent.js
@@ -26,7 +26,8 @@ export default class SimpleModeButtonComponent extends Component {
 
     const eventBus = this._eventBus = injector.get('eventBus'),
           simpleMode = injector.get('simpleMode'),
-          elementRegistry = context.injector.get('elementRegistry');
+          elementRegistry = context.injector.get('elementRegistry'),
+          expressionLanguages = context.injector.get('expressionLanguages');
 
     this._renderer = injector.get('renderer');
 
@@ -52,7 +53,9 @@ export default class SimpleModeButtonComponent extends Component {
 
       const expressionLanguage = getExpressionLanguage(selection);
 
-      const isDisabled = !isDefaultExpressionLanguage(selection, expressionLanguage);
+      const isDisabled = !isDefaultExpressionLanguage(
+        selection, expressionLanguage, expressionLanguages
+      );
 
       this.setState({
         isVisible: true,
@@ -190,10 +193,15 @@ function getExpressionLanguage(cell) {
   return cell.businessObject.expressionLanguage;
 }
 
-function isDefaultExpressionLanguage(cell, expressionLanguage) {
+function isDefaultExpressionLanguage(cell, expressionLanguage, expressionLanguages) {
+  return !expressionLanguage ||
+    expressionLanguage === getDefaultExpressionLanguage(cell, expressionLanguages);
+}
+
+function getDefaultExpressionLanguage(cell, expressionLanguages) {
   if (isInput(cell.col)) {
-    return !expressionLanguage || expressionLanguage === 'feel';
+    return expressionLanguages.getDefault('inputCell').value;
   } else if (isOutput(cell.col)) {
-    return !expressionLanguage || expressionLanguage === 'juel';
+    return expressionLanguages.getDefault('outputCell').value;
   }
 }

--- a/packages/dmn-js-decision-table/src/features/simple-mode/index.js
+++ b/packages/dmn-js-decision-table/src/features/simple-mode/index.js
@@ -1,12 +1,14 @@
 import ContextMenu from 'table-js/lib/features/context-menu';
 import CellSelection from '../cell-selection';
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
 
 import SimpleMode from './SimpleMode';
 
 export default {
   __depends__: [
     ContextMenu,
-    CellSelection
+    CellSelection,
+    ExpressionLanguagesModule
   ],
   __init__: [ 'simpleMode' ],
   simpleMode: [ 'type', SimpleMode ]

--- a/packages/dmn-js-decision-table/test/spec/expression-language.dmn
+++ b/packages/dmn-js-decision-table/test/spec/expression-language.dmn
@@ -26,13 +26,13 @@
         <inputEntry id="inputEntry1" expressionLanguage="javascript">
           <text><![CDATA["bronze"]]></text>
         </inputEntry>
-        <inputEntry id="inputEntry2">
+        <inputEntry id="inputEntry2" expressionLanguage="feel">
           <text></text>
         </inputEntry>
         <outputEntry id="outputEntry1" expressionLanguage="javascript">
           <text><![CDATA["notok"]]></text>
         </outputEntry>
-        <outputEntry id="outputEntry2">
+        <outputEntry id="outputEntry2" expressionLanguage="juel">
           <text><![CDATA["work on your status first, as bronze you're not going to get anything"]]></text>
         </outputEntry>
       </rule>

--- a/packages/dmn-js-decision-table/test/spec/expression-language.dmn
+++ b/packages/dmn-js-decision-table/test/spec/expression-language.dmn
@@ -23,10 +23,10 @@
       <output id="output2" label="Reason" name="reason" typeRef="string" />
       <rule id="rule1">
         <description>Bronze is really not that good</description>
-        <inputEntry id="inputEntry1" expressionLanguage="javascript">
+        <inputEntry id="inputEntry1" expressionLanguage="jruby">
           <text><![CDATA["bronze"]]></text>
         </inputEntry>
-        <inputEntry id="inputEntry2" expressionLanguage="feel">
+        <inputEntry id="inputEntry2">
           <text></text>
         </inputEntry>
         <outputEntry id="outputEntry1" expressionLanguage="javascript">

--- a/packages/dmn-js-decision-table/test/spec/features/decision-rules/DecisionRulesEditorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-rules/DecisionRulesEditorSpec.js
@@ -186,10 +186,10 @@ describe('features/decision-rules', function() {
 
       describe('on input', function() {
 
-        it('should not default', function() {
+        it('should not display default', function() {
 
           // given
-          const cell = domQuery('[data-element-id="inputEntry1"]', testContainer);
+          const cell = domQuery('[data-element-id="inputEntry2"]', testContainer);
 
           // then
           expect(domQuery('.dmn-expression-language', cell)).to.not.exist;
@@ -199,7 +199,7 @@ describe('features/decision-rules', function() {
         it('should display non-default', function() {
 
           // given
-          const cell = domQuery('[data-element-id="inputEntry2"]', testContainer);
+          const cell = domQuery('[data-element-id="inputEntry1"]', testContainer);
 
           // then
           expect(domQuery('.dmn-expression-language', cell)).to.exist;
@@ -209,9 +209,9 @@ describe('features/decision-rules', function() {
         it('should not display if focussed', function() {
 
           // given
-          const cell = domQuery('[data-element-id="inputEntry2"]', testContainer);
+          const cell = domQuery('[data-element-id="inputEntry1"]', testContainer);
 
-          const editor = queryEditor('[data-element-id="inputEntry2"]', testContainer);
+          const editor = queryEditor('[data-element-id="inputEntry1"]', testContainer);
 
           // when
           editor.focus();

--- a/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorCellSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorCellSpec.js
@@ -111,7 +111,7 @@ describe('decision-table-head/editor - input', function() {
 
       // then
       expect(inputBo.inputExpression.text).to.equal('foo\nbar');
-      expect(inputBo.inputExpression.expressionLanguage).to.equal('JUEL');
+      expect(inputBo.inputExpression.expressionLanguage).to.equal('juel');
     }));
 
 
@@ -126,7 +126,7 @@ describe('decision-table-head/editor - input', function() {
       triggerClick(makeScriptEl);
 
       // then
-      expect(inputBo.inputExpression.expressionLanguage).to.equal('JUEL');
+      expect(inputBo.inputExpression.expressionLanguage).to.equal('juel');
     }));
 
   });

--- a/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorSpec.js
@@ -45,6 +45,11 @@ class Root extends Component {
     this.state = {
       text: '',
       expressionLanguage: '',
+      expressionLanguages: [],
+      defaultExpressionLanguage: {
+        value: 'feel',
+        label: 'FEEL'
+      },
       inputVariable: null,
       label: null
     };

--- a/packages/dmn-js-literal-expression/src/Editor.js
+++ b/packages/dmn-js-literal-expression/src/Editor.js
@@ -1,3 +1,5 @@
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
+
 import Viewer from './Viewer';
 
 import DecisionPropertiesEditorModule from './features/decision-properties/editor';
@@ -21,6 +23,7 @@ export default class Editor extends Viewer {
       KeyboardModule,
       LiteralExpressionPropertiesEditorModule,
       ModelingModule,
+      ExpressionLanguagesModule,
       TextareaEditorComponent
     ];
   }

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
@@ -3,26 +3,6 @@ import { Component } from 'inferno';
 import Input from 'dmn-js-shared/lib/components/Input';
 import InputSelect from 'dmn-js-shared/lib/components/InputSelect';
 
-const EXPRESSION_LANGUAGE_OPTIONS = [{
-  label: 'FEEL',
-  value: 'feel'
-}, {
-  label: 'JUEL',
-  value: 'juel'
-}, {
-  label: 'JavaScript',
-  value: 'javascript'
-}, {
-  label: 'Groovy',
-  value: 'groovy'
-}, {
-  label: 'Python',
-  value: 'python'
-}, {
-  label: 'JRuby',
-  value: 'jruby'
-}];
-
 const TYPE_REF_OPTIONS = [{
   label: 'string',
   value: 'string'
@@ -50,6 +30,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
 
     this._viewer = context.injector.get('viewer');
     this._modeling = context.injector.get('modeling');
+    this._expressionLanguages = context.injector.get('expressionLanguages');
 
     const decision = this._viewer.getDecision();
 
@@ -105,7 +86,9 @@ export default class LiteralExpressionPropertiesComponent extends Component {
   }
 
   render() {
-    let { expressionLanguage, name, typeRef } = this.state;
+    const { expressionLanguage, name, typeRef } = this.state;
+
+    const languageOptions = this._expressionLanguages.getAll();
 
     return (
       <div className="literal-expression-properties">
@@ -138,7 +121,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
               <div className="dms-fill-row">
                 <InputSelect
                   onChange={ this.setExpressionLanguage }
-                  options={ EXPRESSION_LANGUAGE_OPTIONS }
+                  options={ languageOptions }
                   value={ expressionLanguage }
                   className="expression-language-select dms-block" />
               </div>

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/index.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/index.js
@@ -1,6 +1,11 @@
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
+
 import LiteralExpressionProperties from './LiteralExpressionProperties';
 
 export default {
+  __depends__: [
+    ExpressionLanguagesModule
+  ],
   __init__: [ 'literalExpressionProperties' ],
   literalExpressionProperties: [ 'type', LiteralExpressionProperties ]
 };

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
@@ -5,6 +5,8 @@ import {
   triggerInputSelectChange
 } from 'dmn-js-shared/test/util/EventUtil';
 
+import ExpressionLanguagesModule from 'dmn-js-shared/lib/features/expression-languages';
+
 import {
   query as domQuery
 } from 'min-dom';
@@ -26,6 +28,7 @@ describe('literal expression properties editor', function() {
     modules: [
       CoreModule,
       LiteralExpressionPropertiesEditorModule,
+      ExpressionLanguagesModule,
       ModelingModule
     ],
     debounceInput: false

--- a/packages/dmn-js-shared/src/features/expression-languages/ExpressionLanguages.js
+++ b/packages/dmn-js-shared/src/features/expression-languages/ExpressionLanguages.js
@@ -1,0 +1,133 @@
+import { assign } from 'min-dash';
+
+
+const EXPRESSION_LANGUAGE_OPTIONS = [{
+  label: 'FEEL',
+  value: 'feel'
+}, {
+  label: 'JUEL',
+  value: 'juel'
+}, {
+  label: 'JavaScript',
+  value: 'javascript'
+}, {
+  label: 'Groovy',
+  value: 'groovy'
+}, {
+  label: 'Python',
+  value: 'python'
+}, {
+  label: 'JRuby',
+  value: 'jruby'
+}];
+
+/**
+ * @typedef ExpressionLanguageDescriptor
+ * @property {string} value - value inserted into XML
+ * @property {string} label - human-readable label
+ */
+
+/**
+ * Provide options and defaults of expression languages via config.
+ *
+ * @example
+ *
+ * // there will be two languages available with FEEL as default
+ * const editor = new DmnJS({
+ *   expressionLanguages: {
+ *     options: [{
+ *       value: 'feel',
+ *       label: 'FEEL'
+ *     }, {
+ *       value: 'juel',
+ *       label: 'JUEL'
+ *     }],
+ *     defaults: {
+ *       editor: 'feel'
+ *     }
+ *   }
+ * })
+ */
+export default class ExpressionLanguages {
+  constructor(injector) {
+    this._injector = injector;
+
+    const config = injector.get('config.expressionLanguages') || {};
+
+    this._config = {
+      options: EXPRESSION_LANGUAGE_OPTIONS,
+      defaults: {
+        editor: 'juel',
+        inputCell: 'feel'
+      }
+    };
+
+    // first assign the list of languages as it might be required for the legacy defaults
+    if (config.options) {
+      this._config.options = config.options;
+    }
+
+    const legacyDefaults = this._getLegacyDefaults();
+
+    assign(this._config.defaults, legacyDefaults, config.defaults);
+  }
+
+  /**
+   * Get default expression language for a component or the editor if `componentName`
+   * is not provided.
+   *
+   * @param {string} [componentName]
+   * @returns {ExpressionLanguageDescriptor}
+   */
+  getDefault(componentName) {
+    const { defaults } = this._config;
+    const defaultFromConfig = defaults[componentName] || defaults.editor;
+
+    return this._getLanguageByValue(defaultFromConfig) || this.getAll()[0];
+  }
+
+  /**
+   * Get label for provided expression language.
+   *
+   * @param {string} expressionLanguageValue - value from XML
+   * @returns {string}
+   */
+  getLabel(expressionLanguageValue) {
+    const langauge = this._getLanguageByValue(expressionLanguageValue);
+
+    return langauge ? langauge.label : expressionLanguageValue;
+  }
+
+  /**
+   * Get list of configured expression languages.
+   *
+   * @returns {ExpressionLanguageDescriptor[]}
+   */
+  getAll() {
+    return this._config.options;
+  }
+
+  _getLegacyDefaults() {
+    const defaults = {},
+          injector = this._injector;
+
+    const inputCellValue = injector.get('config.defaultInputExpressionLanguage');
+    const outputCellValue = injector.get('config.defaultOutputExpressionLanguage');
+
+    if (inputCellValue) {
+      defaults.inputCell = inputCellValue;
+    }
+
+    if (outputCellValue) {
+      defaults.outputCell = outputCellValue;
+    }
+
+    return defaults;
+  }
+
+  _getLanguageByValue(value) {
+    return this.getAll().find(language => value === language.value);
+  }
+}
+
+ExpressionLanguages.$inject = [ 'injector' ];

--- a/packages/dmn-js-shared/src/features/expression-languages/index.js
+++ b/packages/dmn-js-shared/src/features/expression-languages/index.js
@@ -1,0 +1,6 @@
+import ExpressionLanguages from './ExpressionLanguages';
+
+export default {
+  __init__: [ 'expressionLanguages' ],
+  expressionLanguages: [ 'type', ExpressionLanguages ]
+};

--- a/packages/dmn-js-shared/test/spec/features/expression-languages/ExpressionLanguagesSpec.js
+++ b/packages/dmn-js-shared/test/spec/features/expression-languages/ExpressionLanguagesSpec.js
@@ -1,0 +1,151 @@
+import { bootstrap, getViewerJS } from '../../base/viewer/TestHelper';
+
+import ExpressionLanguagesModule from 'lib/features/expression-languages';
+
+
+const DEFAULT_OPTIONS = [{
+  label: 'FEEL',
+  value: 'feel'
+}, {
+  label: 'JUEL',
+  value: 'juel'
+}, {
+  label: 'JavaScript',
+  value: 'javascript'
+}, {
+  label: 'Groovy',
+  value: 'groovy'
+}, {
+  label: 'Python',
+  value: 'python'
+}, {
+  label: 'JRuby',
+  value: 'jruby'
+}];
+
+
+describe('ExpressionLanguages', function() {
+
+  describe('defaults', () => {
+
+    it('should set default editor expression language to JUEL', () => {
+
+      // given
+      const expressionLanguages = createExpressionLanguages();
+
+      // when
+      const defaultLanguage = expressionLanguages.getDefault('editor');
+
+      // then
+      expect(defaultLanguage).to.have.property('value', 'juel');
+      expect(defaultLanguage).to.have.property('label', 'JUEL');
+    });
+
+
+    it('should set default input cell expression language to FEEL', () => {
+
+      // given
+      const expressionLanguages = createExpressionLanguages();
+
+      // when
+      const defaultLanguage = expressionLanguages.getDefault('inputCell');
+
+      // then
+      expect(defaultLanguage).to.have.property('value', 'feel');
+      expect(defaultLanguage).to.have.property('label', 'FEEL');
+    });
+
+
+    it('should use user provided defaults', () => {
+
+      // given
+      const expressionLanguages = createExpressionLanguages({
+        expressionLanguages: {
+          defaults: {
+            editor: 'javascript',
+            inputCell: 'jruby'
+          }
+        }
+      });
+
+      // when
+      const editorDefault = expressionLanguages.getDefault('editor');
+      const inputCellDefault = expressionLanguages.getDefault('inputCell');
+
+      // then
+      expect(editorDefault).to.have.property('value', 'javascript');
+      expect(editorDefault).to.have.property('label', 'JavaScript');
+      expect(inputCellDefault).to.have.property('value', 'jruby');
+      expect(inputCellDefault).to.have.property('label', 'JRuby');
+    });
+
+
+    it('should support legacy defaults', () => {
+
+      // given
+      const expressionLanguages = createExpressionLanguages({
+        defaultInputExpressionLanguage: 'jruby',
+        defaultOutputExpressionLanguage: 'javascript'
+      });
+
+      // when
+      const inputCellDefault = expressionLanguages.getDefault('inputCell');
+      const outputCellDefault = expressionLanguages.getDefault('outputCell');
+
+      // then
+      expect(inputCellDefault).to.have.property('value', 'jruby');
+      expect(inputCellDefault).to.have.property('label', 'JRuby');
+      expect(outputCellDefault).to.have.property('value', 'javascript');
+      expect(outputCellDefault).to.have.property('label', 'JavaScript');
+
+    });
+  });
+
+
+  describe('options', () => {
+
+    it('should correctly set default options', () => {
+
+      // given
+      const expressionLanguages = createExpressionLanguages();
+
+      // when
+      const options = expressionLanguages.getAll();
+
+      // then
+      expect(options).to.deep.eql(DEFAULT_OPTIONS);
+    });
+
+
+    it('should use provided options', () => {
+
+      // given
+      const providedOptions = DEFAULT_OPTIONS.slice(1, 3);
+      const expressionLanguages = createExpressionLanguages({
+        expressionLanguages: {
+          options: providedOptions
+        }
+      });
+
+      // when
+      const options = expressionLanguages.getAll();
+
+      // then
+      expect(options).to.deep.eql(providedOptions);
+    });
+  });
+});
+
+
+
+// helper
+function createExpressionLanguages(config) {
+  bootstrap({
+    modules: [
+      ExpressionLanguagesModule
+    ],
+    ...config
+  })();
+
+  return getViewerJS().get('expressionLanguages');
+}

--- a/packages/dmn-js-shared/test/spec/features/expression-languages/ExpressionLanguagesSpec.js
+++ b/packages/dmn-js-shared/test/spec/features/expression-languages/ExpressionLanguagesSpec.js
@@ -37,8 +37,10 @@ describe('ExpressionLanguages', function() {
       const defaultLanguage = expressionLanguages.getDefault('editor');
 
       // then
-      expect(defaultLanguage).to.have.property('value', 'juel');
-      expect(defaultLanguage).to.have.property('label', 'JUEL');
+      expect(defaultLanguage).to.eql({
+        value: 'juel',
+        label: 'JUEL'
+      });
     });
 
 
@@ -51,8 +53,10 @@ describe('ExpressionLanguages', function() {
       const defaultLanguage = expressionLanguages.getDefault('inputCell');
 
       // then
-      expect(defaultLanguage).to.have.property('value', 'feel');
-      expect(defaultLanguage).to.have.property('label', 'FEEL');
+      expect(defaultLanguage).to.eql({
+        value: 'feel',
+        label: 'FEEL'
+      });
     });
 
 
@@ -73,10 +77,14 @@ describe('ExpressionLanguages', function() {
       const inputCellDefault = expressionLanguages.getDefault('inputCell');
 
       // then
-      expect(editorDefault).to.have.property('value', 'javascript');
-      expect(editorDefault).to.have.property('label', 'JavaScript');
-      expect(inputCellDefault).to.have.property('value', 'jruby');
-      expect(inputCellDefault).to.have.property('label', 'JRuby');
+      expect(inputCellDefault).to.eql({
+        value: 'jruby',
+        label: 'JRuby'
+      });
+      expect(editorDefault).to.eql({
+        value: 'javascript',
+        label: 'JavaScript'
+      });
     });
 
 
@@ -93,11 +101,14 @@ describe('ExpressionLanguages', function() {
       const outputCellDefault = expressionLanguages.getDefault('outputCell');
 
       // then
-      expect(inputCellDefault).to.have.property('value', 'jruby');
-      expect(inputCellDefault).to.have.property('label', 'JRuby');
-      expect(outputCellDefault).to.have.property('value', 'javascript');
-      expect(outputCellDefault).to.have.property('label', 'JavaScript');
-
+      expect(inputCellDefault).to.eql({
+        value: 'jruby',
+        label: 'JRuby'
+      });
+      expect(outputCellDefault).to.eql({
+        value: 'javascript',
+        label: 'JavaScript'
+      });
     });
   });
 


### PR DESCRIPTION
This adds `ExpressionLanguages` module which reads the config
in order to provide available expression language options
as well as defaults for the editor and selected components.

Closes #433