### PR TITLE
Provide titles for all entries

### DIFF
--- a/packages/dmn-js-drd/src/features/palette/PaletteProvider.js
+++ b/packages/dmn-js-drd/src/features/palette/PaletteProvider.js
@@ -71,16 +71,18 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
       separator: true
     },
     'create.decision': createAction(
-      'dmn:Decision', 'drd', 'dmn-icon-decision'
+      'dmn:Decision', 'drd', 'dmn-icon-decision', translate('Create Decision')
     ),
     'create.input-data': createAction(
-      'dmn:InputData', 'drd', 'dmn-icon-input-data'
+      'dmn:InputData', 'drd', 'dmn-icon-input-data', translate('Create Input Data')
     ),
     'create.knowledge-source': createAction(
-      'dmn:KnowledgeSource', 'drd', 'dmn-icon-knowledge-source'
+      'dmn:KnowledgeSource', 'drd', 'dmn-icon-knowledge-source',
+      translate('Create Knowledge Source')
     ),
     'create.business-knowledge-model': createAction(
-      'dmn:BusinessKnowledgeModel', 'drd', 'dmn-icon-business-knowledge'
+      'dmn:BusinessKnowledgeModel', 'drd', 'dmn-icon-business-knowledge',
+      translate('Create Knowledge Model')
     )
   });
 

--- a/packages/dmn-js-drd/test/spec/features/palette/PaletteProviderSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/palette/PaletteProviderSpec.js
@@ -32,4 +32,18 @@ describe('features/palette', function() {
     expect(entries.length).to.equal(5);
   }));
 
+
+  it('should provide title for each palette entry', inject(function(canvas) {
+
+    // when
+    var paletteElement = domQuery('.djs-palette', canvas._container);
+    var entries = domQueryAll('.entry', paletteElement);
+
+    // then
+    entries.forEach(function(entry) {
+      expect(entry).to.have.property('title');
+      expect(entry.title).to.have.lengthOf.above(0);
+    });
+  }));
+
 });


### PR DESCRIPTION
This adds missing titles for palette entries. The naming is based on the way we do it in `bpmn-js`. I think it's worth it to merge this as therefore the users have actually an opportunity to learn the elements' names.