### PR TITLE
DRD: Add basic diagram-js modeling helpers

### DIFF
--- a/packages/dmn-js-drd/src/Modeler.js
+++ b/packages/dmn-js-drd/src/Modeler.js
@@ -2,6 +2,25 @@ import inherits from 'inherits';
 
 import NavigatedViewer from './NavigatedViewer';
 
+import AlignElementsModule from 'diagram-js/lib/features/align-elements';
+import AutoScrollModule from 'diagram-js/lib/features/auto-scroll';
+import BendpointsModule from 'diagram-js/lib/features/bendpoints';
+import ContextPadModule from './features/context-pad';
+import ConnectPreviewModule from 'diagram-js/lib/features/connection-preview';
+import DefinitionPropertiesModule from './features/definition-properties/modeler';
+import DistributeElementsModule from './features/distribute-elements';
+import EditorActionsModule from './features/editor-actions';
+import GenerateDiModule from './features/generate-di';
+import GridSnappingModule from 'diagram-js/lib/features/grid-snapping';
+import KeyboardModule from './features/keyboard';
+import KeyboardMoveModule from 'diagram-js/lib/navigation/keyboard-move';
+import KeyboardMoveSelectionModule from 'diagram-js/lib/features/keyboard-move-selection';
+import LabelEditingModule from './features/label-editing';
+import ModelingModule from './features/modeling';
+import MoveModule from 'diagram-js/lib/features/move';
+import PaletteModule from './features/palette';
+import SnappingModule from 'diagram-js/lib/features/snapping';
+
 /**
  * A modeler for DMN tables.
  *
@@ -90,36 +109,27 @@ inherits(Modeler, NavigatedViewer);
 // - viewer + navigation modules
 // - modeling modules
 
-import BendpointsModule from 'diagram-js/lib/features/bendpoints';
-import ContextPadModule from './features/context-pad';
-import ConnectPreviewModule from 'diagram-js/lib/features/connection-preview';
-import DefinitionPropertiesModule from './features/definition-properties/modeler';
-import EditorActionsModule from './features/editor-actions';
-import GenerateDiModule from './features/generate-di';
-import KeyboardModule from './features/keyboard';
-import KeyboardMoveModule from 'diagram-js/lib/navigation/keyboard-move';
-import KeyboardMoveSelectionModule from 'diagram-js/lib/features/keyboard-move-selection';
-import LabelEditingModule from './features/label-editing';
-import ModelingModule from './features/modeling';
-import MoveModule from 'diagram-js/lib/features/move';
-import PaletteModule from './features/palette';
-
 Modeler.prototype._modelingModules = [
 
   // modeling components
+  AlignElementsModule,
+  AutoScrollModule,
   BendpointsModule,
   ContextPadModule,
   ConnectPreviewModule,
   DefinitionPropertiesModule,
+  DistributeElementsModule,
   EditorActionsModule,
   GenerateDiModule,
+  GridSnappingModule,
   KeyboardModule,
   KeyboardMoveModule,
   KeyboardMoveSelectionModule,
   LabelEditingModule,
   ModelingModule,
   MoveModule,
-  PaletteModule
+  PaletteModule,
+  SnappingModule
 ];
 
 Modeler.prototype._modules = [].concat(

--- a/packages/dmn-js-drd/src/features/distribute-elements/DrdDistributeElements.js
+++ b/packages/dmn-js-drd/src/features/distribute-elements/DrdDistributeElements.js
@@ -1,0 +1,29 @@
+import {
+  filter
+} from 'min-dash';
+
+import {
+  isAny
+} from 'dmn-js-shared/lib/util/ModelUtil';
+
+
+/**
+ * Registers element exclude filters for elements that
+ * currently do not support distribution.
+ */
+export default function DrdDistributeElements(distributeElements) {
+
+  distributeElements.registerFilter(function(elements) {
+    return filter(elements, function(element) {
+
+      // TODO(nikku): add elements that cannot be distributed
+      var cannotDistribute = isAny(element, [
+
+      ]);
+
+      return !(element.labelTarget || cannotDistribute);
+    });
+  });
+}
+
+DrdDistributeElements.$inject = [ 'distributeElements' ];

--- a/packages/dmn-js-drd/src/features/distribute-elements/index.js
+++ b/packages/dmn-js-drd/src/features/distribute-elements/index.js
@@ -1,0 +1,12 @@
+import DistributeElementsModule from 'diagram-js/lib/features/distribute-elements';
+
+import DrdDistributeElements from './DrdDistributeElements';
+
+
+export default {
+  __depends__: [
+    DistributeElementsModule
+  ],
+  __init__: [ 'drdDistributeElements' ],
+  drdDistributeElements: [ 'type', DrdDistributeElements ]
+};

--- a/packages/dmn-js-drd/test/spec/ModelerSpec.js
+++ b/packages/dmn-js-drd/test/spec/ModelerSpec.js
@@ -16,7 +16,14 @@ describe('Modeler', function() {
   });
 
   function createModeler(xml, done) {
-    modeler = new DrdModeler({ container: container });
+    modeler = new DrdModeler({
+      container: container,
+      drd: {
+        keyboard: {
+          bindTo: document
+        }
+      }
+    });
 
     modeler.importXML(xml, function(err, warnings) {
       done(err, warnings, modeler);


### PR DESCRIPTION
Add aligment, distribution and modeling helpers known and loved in bpmn-js:

* snapping
* grid snapping
* keyboard move
* align / distrbute
* automatic canvas movement

__In action__

![capture uhKhRq_optimized](https://user-images.githubusercontent.com/58601/73012436-a19f5d80-3e16-11ea-92de-4afc064077b0.gif)
