### PR TITLE
Enable element distribution

### DIFF
--- a/packages/dmn-js-drd/src/features/distribute-elements/DrdDistributeElements.js
+++ b/packages/dmn-js-drd/src/features/distribute-elements/DrdDistributeElements.js
@@ -16,9 +16,12 @@ export default function DrdDistributeElements(distributeElements) {
   distributeElements.registerFilter(function(elements) {
     return filter(elements, function(element) {
 
-      // TODO(nikku): add elements that cannot be distributed
       var cannotDistribute = isAny(element, [
-
+        'dmn:AuthorityRequirement',
+        'dmn:InformationRequirement',
+        'dmn:KnowledgeRequirement',
+        'dmn:Association',
+        'dmn:TextAnnotation'
       ]);
 
       return !(element.labelTarget || cannotDistribute);

--- a/packages/dmn-js-drd/test/spec/features/distribute-elements/DrdDistributeElements.dmn
+++ b/packages/dmn-js-drd/test/spec/features/distribute-elements/DrdDistributeElements.dmn
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="dish" name="Dish" namespace="http://camunda.org/schema/1.0/dmn">
+  <inputData id="dayType_id" name="Type of day">
+    <extensionElements>
+      <biodi:bounds x="240" y="270" width="125" height="45" />
+    </extensionElements>
+    <variable id="dayType_ii" name="Type of day" typeRef="string" />
+  </inputData>
+  <inputData id="temperature_id" name="Weather in Celsius">
+    <extensionElements>
+      <biodi:bounds x="5" y="270" width="125" height="45" />
+    </extensionElements>
+    <variable id="temperature_ii" name="Weather in Celsius" typeRef="integer" />
+  </inputData>
+  <knowledgeSource id="host_ks" name="Host">
+    <extensionElements>
+      <biodi:bounds x="493" y="4" width="100" height="63" />
+    </extensionElements>
+  </knowledgeSource>
+  <knowledgeSource id="guest_ks" name="Guest Type">
+    <extensionElements>
+      <biodi:bounds x="495" y="147" width="100" height="63" />
+      <biodi:edge source="guestCount">
+        <biodi:waypoints x="410" y="172" />
+        <biodi:waypoints x="495" y="172" />
+      </biodi:edge>
+    </extensionElements>
+    <authorityRequirement>
+      <requiredDecision href="#guestCount" />
+    </authorityRequirement>
+  </knowledgeSource>
+  <businessKnowledgeModel id="elMenu" name="El menú">
+    <extensionElements>
+      <biodi:bounds x="450" y="250" width="135" height="46" />
+    </extensionElements>
+  </businessKnowledgeModel>
+  <textAnnotation id="TextAnnotation_1t4zaz9">
+    <extensionElements>
+      <biodi:bounds x="240" y="400" width="125" height="45" />
+    </extensionElements>
+    <text>foobar</text>
+  </textAnnotation>
+  <association id="Association_1c4jixb">
+    <extensionElements>
+      <biodi:edge source="dayType_id">
+        <biodi:waypoints x="275" y="315" />
+        <biodi:waypoints x="240" y="400" />
+      </biodi:edge>
+    </extensionElements>
+    <sourceRef href="#dayType_id" />
+    <targetRef href="#TextAnnotation_1t4zaz9" />
+  </association>
+  <decision id="dish-decision" name="Dish Decision">
+    <extensionElements>
+      <biodi:bounds x="140" y="5" width="180" height="80" />
+      <biodi:edge source="season">
+        <biodi:waypoints x="80" y="132" />
+        <biodi:waypoints x="140" y="81" />
+      </biodi:edge>
+      <biodi:edge source="guestCount">
+        <biodi:waypoints x="345" y="138" />
+        <biodi:waypoints x="257" y="85" />
+      </biodi:edge>
+      <biodi:edge source="host_ks">
+        <biodi:waypoints x="493" y="24" />
+        <biodi:waypoints x="320" y="25" />
+      </biodi:edge>
+    </extensionElements>
+    <informationRequirement>
+      <requiredDecision href="#season" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#guestCount" />
+    </informationRequirement>
+    <authorityRequirement>
+      <requiredAuthority href="#host_ks" />
+    </authorityRequirement>
+    <decisionTable id="dishDecisionTable">
+      <input id="seasonInput" label="Season">
+        <inputExpression id="seasonInputExpression" typeRef="string">
+          <text>season</text>
+        </inputExpression>
+      </input>
+      <input id="guestCountInput" label="How many guests">
+        <inputExpression id="guestCountInputExpression" typeRef="integer">
+          <text>guestCount</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="Dish" name="desiredDish" typeRef="string" />
+      <rule id="row-495762709-1">
+        <inputEntry id="UnaryTests_1nxcsjr">
+          <text><![CDATA["Winter"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1r9yorj">
+          <text><![CDATA[<= 8]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1mtwzqz">
+          <text><![CDATA["Spareribs"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-495762709-2">
+        <inputEntry id="UnaryTests_1lxjbif">
+          <text><![CDATA["Winter"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0nhiedb">
+          <text><![CDATA[> 8]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1h30r12">
+          <text><![CDATA["Pasta"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-495762709-3">
+        <inputEntry id="UnaryTests_0ifgmfm">
+          <text><![CDATA["Summer"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12cib9m">
+          <text><![CDATA[> 10]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0wgaegy">
+          <text><![CDATA["Light salad"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-495762709-7">
+        <inputEntry id="UnaryTests_0ozm9s7">
+          <text><![CDATA["Summer"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0sesgov">
+          <text><![CDATA[<= 10]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1dvc5x3">
+          <text><![CDATA["Beans salad"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-445981423-3">
+        <inputEntry id="UnaryTests_1er0je1">
+          <text><![CDATA["Spring"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1uzqner">
+          <text><![CDATA[< 10]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1pxy4g1">
+          <text><![CDATA["Stew"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-445981423-4">
+        <inputEntry id="UnaryTests_06or48g">
+          <text><![CDATA["Spring"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wa71sy">
+          <text><![CDATA[>= 10]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_09ggol9">
+          <text><![CDATA["Steak"]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="season" name="Season decision">
+    <extensionElements>
+      <biodi:bounds x="10" y="132" width="180" height="80" />
+      <biodi:edge source="temperature_id">
+        <biodi:waypoints x="80" y="270" />
+        <biodi:waypoints x="80" y="212" />
+      </biodi:edge>
+    </extensionElements>
+    <informationRequirement>
+      <requiredInput href="#temperature_id" />
+    </informationRequirement>
+    <decisionTable id="seasonDecisionTable">
+      <input id="temperatureInput" label="Weather in Celsius">
+        <inputExpression id="temperatureInputExpression" typeRef="integer">
+          <text>temperature</text>
+        </inputExpression>
+      </input>
+      <output id="seasonOutput" label="season" name="season" typeRef="string" />
+      <rule id="row-495762709-5">
+        <inputEntry id="UnaryTests_1fd0eqo">
+          <text><![CDATA[>30]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0l98klb">
+          <text><![CDATA["Summer"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-495762709-6">
+        <inputEntry id="UnaryTests_1nz6at2">
+          <text><![CDATA[<10]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_08moy1k">
+          <text><![CDATA["Winter"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="row-445981423-2">
+        <inputEntry id="UnaryTests_1a0imxy">
+          <text>[10..30]</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1poftw4">
+          <text><![CDATA["Spring"]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="guestCount" name="Guest Count">
+    <extensionElements>
+      <biodi:bounds x="230" y="138" width="180" height="80" />
+      <biodi:edge source="dayType_id">
+        <biodi:waypoints x="340" y="270" />
+        <biodi:waypoints x="340" y="218" />
+      </biodi:edge>
+      <biodi:edge source="elMenu">
+        <biodi:waypoints x="450" y="275" />
+        <biodi:waypoints x="410" y="209" />
+      </biodi:edge>
+    </extensionElements>
+    <informationRequirement>
+      <requiredInput href="#dayType_id" />
+    </informationRequirement>
+    <knowledgeRequirement>
+      <requiredKnowledge href="#elMenu" />
+    </knowledgeRequirement>
+    <decisionTable id="guestCountDecisionTable">
+      <input id="typeOfDayInput" label="Type of day">
+        <inputExpression id="typeOfDayInputExpression" typeRef="string">
+          <text>dayType</text>
+        </inputExpression>
+      </input>
+      <output id="guestCountOutput" label="Guest count" name="guestCount" typeRef="integer" />
+      <rule id="row-495762709-8">
+        <inputEntry id="UnaryTests_0l72u8n">
+          <text><![CDATA["Weekday"]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0wuwqaz">
+          <text>4</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-495762709-9">
+        <inputEntry id="UnaryTests_03a73o9">
+          <text><![CDATA["Holiday"]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1whn119">
+          <text>10</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-495762709-10">
+        <inputEntry id="UnaryTests_12tygwt">
+          <text><![CDATA["Weekend"]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1b5k9t8">
+          <text>15</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/distribute-elements/DrdDistributeElementsSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/distribute-elements/DrdDistributeElementsSpec.js
@@ -1,0 +1,75 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'src/features/modeling';
+import distributeElementsModule from 'src/features/distribute-elements';
+import coreModule from 'src/core';
+
+
+describe('features/distribute-elements', function() {
+
+  var testModules = [
+    coreModule,
+    distributeElementsModule,
+    modelingModule
+  ];
+
+  var diagramXML = require('./DrdDistributeElements.dmn');
+
+
+  beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+  var elements;
+
+  beforeEach(inject(function(elementRegistry, canvas) {
+    elements = elementRegistry.filter(function(element) {
+      return element.parent;
+    });
+  }));
+
+
+  it('should align horizontally', inject(function(distributeElements) {
+
+    // when
+    var rangeGroups = distributeElements.trigger(elements, 'horizontal'),
+        margin = rangeGroups[1].range.min - rangeGroups[0].range.max;
+
+    // then
+    expect(rangeGroups).to.have.length(3);
+
+    expect(margin).to.equal(-17.5);
+
+    expect(rangeGroups[0].range).to.eql({ min: -22.5, max: 157.5 });
+
+    expect(last(rangeGroups).range).to.eql({ min: 477.5, max: 612.5 });
+
+  }));
+
+
+  it('should align vertically', inject(function(distributeElements) {
+
+    // when
+    var rangeGroups = distributeElements.trigger(elements, 'vertical'),
+        margin = rangeGroups[1].range.min - rangeGroups[0].range.max;
+
+    // then
+    expect(rangeGroups).to.have.length(3);
+
+    expect(margin).to.equal(56.5);
+
+    expect(rangeGroups[0].range).to.eql({ min: -4.5, max: 75.5 });
+
+    expect(last(rangeGroups).range).to.eql({ min: 269.5, max: 315.5 });
+
+  }));
+
+});
+
+
+// helpers ////////////////
+
+function last(arr) {
+  return arr[arr.length - 1];
+}


### PR DESCRIPTION
This PR enables proper element distribution in DRD diagrams.

Distribution is not blind to existing element aligments. If it finds certain axis it will group elements so that they are on the same axis (as seen in the screenshots below). So in this sense, it automatically generates levels as prototyped in https://github.com/bpmn-io/dmn-js/issues/450.

Also as seen in the screenshots below, we may want to invest some more time to properly fix connection layouts after distribution took place. I consider this a future improvement.


__Input__

![image](https://user-images.githubusercontent.com/58601/73055304-d1894800-3e8c-11ea-9ce2-bc51e6588f97.png)

__Distribute Horizontally__

![image](https://user-images.githubusercontent.com/58601/73055371-ec5bbc80-3e8c-11ea-8b15-a46ab13c1287.png)


__Distribute Vertically__

![image](https://user-images.githubusercontent.com/58601/73055436-14e3b680-3e8d-11ea-9bdd-b6e29be9cb00.png)
