### PR TITLE
Rename `updateProperties` to `element.updateProperties`

### DIFF
--- a/packages/dmn-js-decision-table/src/features/allowed-values/behavior/AllowedValuesUpdateBehavior.js
+++ b/packages/dmn-js-decision-table/src/features/allowed-values/behavior/AllowedValuesUpdateBehavior.js
@@ -11,7 +11,7 @@ export default class AllowedValuesUpdateBehavior extends CommandInterceptor {
   constructor(eventBus, modeling) {
     super(eventBus);
 
-    this.postExecuted('updateProperties', event => {
+    this.postExecuted('element.updateProperties', event => {
       const {
         element,
         properties

--- a/packages/dmn-js-decision-table/src/features/modeling/Modeling.js
+++ b/packages/dmn-js-decision-table/src/features/modeling/Modeling.js
@@ -26,7 +26,7 @@ export default class Modeling extends BaseModeling {
   static _getHandlers() {
     return assign({}, super._getHandlers(), {
       'editAllowedValues': UpdateAllowedValuesHandler,
-      'updateProperties': UpdatePropertiesHandler,
+      'element.updateProperties': UpdatePropertiesHandler,
       'id.updateClaim': IdClaimHandler
     });
   }
@@ -43,7 +43,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editDecisionTableId(id) {
@@ -58,7 +58,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editHitPolicy(hitPolicy, aggregation) {
@@ -73,7 +73,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   updateProperties(el, props) {
@@ -82,7 +82,7 @@ export default class Modeling extends BaseModeling {
       properties: props
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editInputExpression(inputExpression, props) {
@@ -91,7 +91,7 @@ export default class Modeling extends BaseModeling {
       properties: props
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editOutputName(output, name) {
@@ -102,7 +102,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editInputExpressionTypeRef(inputExpression, typeRef) {
@@ -113,7 +113,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editOutputTypeRef(output, typeRef) {
@@ -124,7 +124,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editCell(cell, text) {
@@ -135,7 +135,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editAnnotation(rule, description) {
@@ -146,7 +146,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editAllowedValues(element, allowedValues) {
@@ -166,7 +166,7 @@ export default class Modeling extends BaseModeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   claimId(id, moddleElement) {

--- a/packages/dmn-js-literal-expression/src/features/modeling/Modeling.js
+++ b/packages/dmn-js-literal-expression/src/features/modeling/Modeling.js
@@ -26,7 +26,7 @@ export default class Modeling {
 
   static _getHandlers() {
     return {
-      'updateProperties': UpdatePropertiesHandler
+      'element.updateProperties': UpdatePropertiesHandler
     };
   }
 
@@ -44,7 +44,7 @@ export default class Modeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editDecisionId(id) {
@@ -57,7 +57,7 @@ export default class Modeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editLiteralExpressionText(text) {
@@ -71,7 +71,7 @@ export default class Modeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editExpressionLanguage(expressionLanguage) {
@@ -85,7 +85,7 @@ export default class Modeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editVariableName(name) {
@@ -99,7 +99,7 @@ export default class Modeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 
   editVariableType(typeRef) {
@@ -113,7 +113,7 @@ export default class Modeling {
       }
     };
 
-    this._commandStack.execute('updateProperties', context);
+    this._commandStack.execute('element.updateProperties', context);
   }
 }
 

--- a/packages/dmn-js-shared/src/features/modeling/behavior/IdChangeBehavior.js
+++ b/packages/dmn-js-shared/src/features/modeling/behavior/IdChangeBehavior.js
@@ -11,7 +11,7 @@ export default class IdChangeBehavior extends CommandInterceptor {
   constructor(eventBus) {
     super(eventBus);
 
-    this.executed('updateProperties', this.updateIds.bind(this));
+    this.executed('element.updateProperties', this.updateIds.bind(this));
   }
 
   updateIds({ context }) {


### PR DESCRIPTION
This ensures consistency between dmn-js-drd and remaining packages. Previously, the packages executed differently named commands for the same feature. This led to [a workaround in `dmn-js-properties-panel`](https://github.com/bpmn-io/dmn-js-properties-panel/blob/70bc931c4a570dd5e1ede42dd275ce19b38485af/lib/adapter/decision-table/DecisionTableAdapter.js#L37). If we merge this change, we can get rid of the workarounds. Also, fix for https://github.com/camunda/camunda-modeler/issues/1679 will not require a workaround in the [`IdChangeBehavior`](https://github.com/bpmn-io/dmn-js/blob/develop/packages/dmn-js-shared/src/features/modeling/behavior/IdChangeBehavior.js#L14).

BTW, we use `element.updateProperties` [in `bpmn-js` too.](https://github.com/bpmn-io/bpmn-js/blob/0c0ebea49f8b20e317ca28b157da5d4ecb3617c6/lib/features/modeling/Modeling.js#L47)

BREAKING CHANGES:

* `Modeling` in decision table and literal expression executes
  `element.updateProperties` command instead of `updateProperties`.