### PR TITLE
No output placeholder 8.x

### DIFF
--- a/packages/dmn-js-decision-table/src/features/decision-rules/components/DecisionRulesCellEditorComponent.js
+++ b/packages/dmn-js-decision-table/src/features/decision-rules/components/DecisionRulesCellEditorComponent.js
@@ -82,13 +82,12 @@ export default class DecisionRulesEditorCellComponent extends Component {
 
     const { isFocussed } = this.state;
 
-    const className = is(cell, 'dmn:UnaryTests') ? 'input-cell' : 'output-cell';
-
+    const isUnaryTest = is(cell, 'dmn:UnaryTests');
     const businessObject = cell.businessObject;
 
     return (
       <Cell
-        className={ className }
+        className={ isUnaryTest ? 'input-cell' : 'output-cell' }
         elementId={ cell.id }
         coords={ `${rowIndex}:${colIndex}` }
         data-row-id={ row.id }
@@ -96,6 +95,7 @@ export default class DecisionRulesEditorCellComponent extends Component {
       >
         <TableCellEditor
           className="cell-editor"
+          placeholder={ isUnaryTest ? '-' : '' }
           ctrlForNewline={ true }
           onFocus={ this.onFocus }
           onBlur={ this.onBlur }

--- a/packages/dmn-js-decision-table/test/spec/features/decision-rules/DecisionRulesEditorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-rules/DecisionRulesEditorSpec.js
@@ -9,6 +9,7 @@ import { queryEditor } from 'dmn-js-shared/test/util/EditorUtil';
 import TestContainer from 'mocha-test-container-support';
 
 import simpleXML from '../../simple.dmn';
+import emptyRuleXML from './empty-rule.dmn';
 import languageExpressionXML from '../../expression-language.dmn';
 
 import CoreModule from 'src/core';
@@ -262,6 +263,41 @@ describe('features/decision-rules', function() {
       });
 
     });
+
+  });
+
+
+  describe('placeholder', function() {
+
+    beforeEach(bootstrapModeler(emptyRuleXML, {
+      modules: [
+        CoreModule,
+        ModelingModule,
+        DecisionRulesModule,
+        DecisionRulesEditorModule
+      ],
+      debounceInput: false
+    }));
+
+
+    it('should show <-> input placeholder', inject(function() {
+
+      // when
+      const editor = queryEditor('[data-element-id="unaryTest_1"]', testContainer);
+
+      // then
+      expect(editor.textContent).to.eql('-');
+    }));
+
+
+    it('should NOT show <-> output placeholder', inject(function() {
+
+      // when
+      const editor = queryEditor('[data-element-id="outputEntry_1"]', testContainer);
+
+      // then
+      expect(editor.textContent).to.eql('');
+    }));
 
   });
 

--- a/packages/dmn-js-decision-table/test/spec/features/decision-rules/empty-rule.dmn
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-rules/empty-rule.dmn
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="definitions_1y78itg" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="dmn-js (https://demo.bpmn.io/dmn)" exporterVersion="7.4.1">
+  <decision id="decision_1" name="decision_1">
+    <decisionTable id="decisionTable_1">
+      <input id="input1" label="">
+        <inputExpression id="inputExpression1" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="" name="" typeRef="string" />
+      <rule id="decisionRule_1">
+        <inputEntry id="unaryTest_1">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="outputEntry_1">
+          <text></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/packages/dmn-js-shared/src/components/EditableComponent.js
+++ b/packages/dmn-js-shared/src/components/EditableComponent.js
@@ -140,7 +140,8 @@ export default class EditableComponent extends Component {
   getDisplayValue() {
 
     var {
-      value
+      value,
+      placeholder
     } = this.props;
 
     var {
@@ -153,7 +154,7 @@ export default class EditableComponent extends Component {
     }
 
     if (!value) {
-      value = focussed ? '' : '-';
+      value = focussed ? '' : (placeholder || '');
     }
 
     return value;

--- a/packages/dmn-js-shared/test/spec/components/EditableComponentSpec.js
+++ b/packages/dmn-js-shared/test/spec/components/EditableComponentSpec.js
@@ -75,6 +75,18 @@ describe('components/EditableComponent', function() {
     );
 
     // then
+    expect(innerText(node)).to.eql('');
+  });
+
+
+  it('should render with placeholder value', function() {
+
+    // when
+    const node = renderToNode(
+      <TestComponent value={ null } placeholder="-" />
+    );
+
+    // then
     expect(innerText(node)).to.eql('-');
   });
 


### PR DESCRIPTION
This removes the missleading output placeholder `-` from the decision table.

Port of https://github.com/bpmn-io/dmn-js/pull/472 to `develop`.

Related to https://github.com/camunda/camunda-modeler/issues/1677