### PR TITLE
chore(expression-languages): use min-dash find

### DIFF
--- a/packages/dmn-js-shared/src/features/expression-languages/ExpressionLanguages.js
+++ b/packages/dmn-js-shared/src/features/expression-languages/ExpressionLanguages.js
@@ -1,4 +1,7 @@
-import { assign } from 'min-dash';
+import {
+  assign,
+  find
+} from 'min-dash';
 
 
 const EXPRESSION_LANGUAGE_OPTIONS = [{
@@ -126,7 +129,7 @@ export default class ExpressionLanguages {
   }
 
   _getLanguageByValue(value) {
-    return this.getAll().find(language => value === language.value);
+    return find(this.getAll(), language => value === language.value);
   }
 }
 


### PR DESCRIPTION
`Array.prototype.find` is not polyfilled within current
babel config. This caused problem with IE11 where
the function is not implemented.

For more context, before this commit the PhantomJS tests for the properties panel used to fail because of lacking `find`.