### PR TITLE
Prevent updating id if no oldProperties available

### DIFF
--- a/packages/dmn-js-decision-table/test/spec/features/modeling/behavior/IdChangeBehaviorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/modeling/behavior/IdChangeBehaviorSpec.js
@@ -85,4 +85,48 @@ describe('IdChangeBehavior', function() {
     });
   }));
 
+
+  it('should NOT update IDs if no oldProperties given', inject(function(eventBus, sheet) {
+
+    // given
+    const root = sheet.getRoot(),
+          decisionTable = root.businessObject;
+
+    const decision = decisionTable.$parent;
+
+    const definitions = decision.$parent;
+
+    const {
+      artifacts,
+      drgElements
+    } = definitions;
+
+    const dishDecision = drgElements.filter(
+      drgElement => drgElement.id === 'dish-decision'
+    )[0];
+
+    const association = artifacts.filter(
+      element => element.id === 'Association'
+    )[0];
+
+    const event = {
+      context: {
+        oldProperties: null
+      }
+    };
+
+    const dmnJS = getDmnJS();
+
+    dmnJS._viewers.decisionTable.open(dishDecision, () => {
+
+      // when
+      eventBus.fire('commandStack.element.updateProperties.executed', event);
+
+      // then
+      expect(association.sourceRef.href).to.eql('#dish-decision');
+      expect(association.extensionElements.values[0].source).to.eql('dish-decision');
+    });
+  }));
+
+
 });

--- a/packages/dmn-js-shared/src/features/modeling/behavior/IdChangeBehavior.js
+++ b/packages/dmn-js-shared/src/features/modeling/behavior/IdChangeBehavior.js
@@ -47,7 +47,8 @@ export default class IdChangeBehavior extends CommandInterceptor {
   }
 
   shouldSkipUpdate(bo, oldProperties, newProperties) {
-    return !isIdChange(oldProperties, newProperties) ||
+    return !oldProperties ||
+     !isIdChange(oldProperties, newProperties) ||
      (!is(bo, 'dmn:DRGElement') && !is(bo, 'dmn:TextAnnotation'));
   }
 }


### PR DESCRIPTION
Related to camunda/camunda-modeler#1796
Fixes a bug only existing in old v7 version of the library

--------

_Solution Sketch_

The error basically exists because we have to deal with two updating properties events, which is also explained here: https://github.com/camunda/camunda-modeler/issues/1769#issuecomment-614030674
* `updateProperties`
* `elementProperties`

Basically it crashes because the properties panel executes the `element.updateProperties` event, which `dmn-js-decision-table` does not have a handler for. That's why the IdChangeBehavior is executed without `oldProperties` is populated. This got fixed in v8.

However, to backport this fix we can not easily add a temporary `element.updateProperties` handler to the decision table module, because we adding this one in the properties panel itself: https://github.com/bpmn-io/dmn-js-properties-panel/blob/v0.3.4/lib/adapter/decision-table/DecisionTableAdapter.js#L38 (which also got removed in the newest version).

So we would basically have these options:
* Integrating the newest properties panel version to the v3.7x Camunda Modeler version and adding a temporarily `element.updateProperties` handler to the decision table component. 
* Ensuring we do not try to execute the IdChangeBehavior if no `oldProperties` is available in the context, cf. https://github.com/bpmn-io/dmn-js/commit/770a17fa149cd72b0050e7d2190a8d2d12ed6ba6
* Do not do anything and wait for the Camunda Modeler v4 release

I would personally go for the second option since we never really can assure in this state, we always execute the `updateProperties` as we have the inconsistent naming. Since the whole got fixed with dmn-js@8 anyway, I'd rather go with this small fix.

What do you think @bpmn-io/modeling-dev ?

