### PR TITLE
chore(hit-policy): improve viewer style

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
@@ -242,6 +242,11 @@
   margin: 0 10px;
 }
 
+.dmn-decision-table-container .hit-policy-value::after {
+  content: '—';
+  margin-left: 5px;
+}
+
 .dmn-decision-table-container .hit-policy-explanation {
   margin-left: 5px;
   color: #545454;

--- a/packages/dmn-js-decision-table/src/features/hit-policy/components/HitPolicy.js
+++ b/packages/dmn-js-decision-table/src/features/hit-policy/components/HitPolicy.js
@@ -38,7 +38,9 @@ export default class HitPolicy extends Component {
         <label className="dms-label">
           Hit Policy:
         </label>
-        { hitPolicyEntry.label}
+        <span className="hit-policy-value">
+          { hitPolicyEntry.label}
+        </span>
         <span className="hit-policy-explanation">{ hitPolicyEntry.explanation }</span>
       </span>
     );


### PR DESCRIPTION
After the hit policy PR was merged, I noticed that in the viewer it looks kinda odd. This PR is aimed to fix the problem.

Before:
![image](https://user-images.githubusercontent.com/28307541/82341094-4a8a4d80-99f0-11ea-8e46-a36cd8bc25c9.png)

After:
![image](https://user-images.githubusercontent.com/28307541/82341055-3a726e00-99f0-11ea-9368-eb4637d17944.png)
