### PR TITLE
fix(drd/drd-rules): allow association regardless of connection direction

### DIFF
--- a/packages/dmn-js-drd/src/features/rules/DrdRules.js
+++ b/packages/dmn-js-drd/src/features/rules/DrdRules.js
@@ -134,7 +134,8 @@ function canConnect(source, target) {
     return { type: 'dmn:AuthorityRequirement' };
   }
 
-  if (is(target, 'dmn:TextAnnotation')) {
+  if ((is(source, 'dmn:TextAnnotation') && !is(target, 'dmn:TextAnnotation'))
+  || (!is(source, 'dmn:TextAnnotation') && is(target, 'dmn:TextAnnotation'))) {
     return { type: 'dmn:Association' };
   }
 

--- a/packages/dmn-js-drd/test/spec/features/rules/DrdRulesSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/rules/DrdRulesSpec.js
@@ -172,6 +172,20 @@ describe('features/rules', function() {
       { type: 'dmn:AuthorityRequirement' }
     ));
 
+
+    it('decision -> text annotation', expectCanConnect(
+      'Decision_2',
+      'TextAnnotation_1',
+      { type: 'dmn:Association' }
+    ));
+
+
+    it('text annotation -> decision', expectCanConnect(
+      'TextAnnotation_1',
+      'Decision_2',
+      { type: 'dmn:Association' }
+    ));
+
   });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/1817
Related to https://github.com/camunda/camunda-modeler/issues/1702
Related to https://github.com/camunda/camunda-modeler/issues/1763