### PR TITLE
chore(shared/Manager): add extension to camunda moddle import

### DIFF
--- a/packages/dmn-js-shared/src/base/Manager.js
+++ b/packages/dmn-js-shared/src/base/Manager.js
@@ -2,7 +2,7 @@ import EventBus from 'diagram-js/lib/core/EventBus';
 
 import DmnModdle from 'dmn-moddle';
 
-import CamundaModdle from 'camunda-dmn-moddle/resources/camunda';
+import CamundaModdle from 'camunda-dmn-moddle/resources/camunda.json';
 
 import {
   domify,


### PR DESCRIPTION
This prevents import error in TypeScript environment.

Closes #517