### PR TITLE
fix(manager): find correct active view when updating views

### DIFF
--- a/packages/dmn-js-shared/src/base/Manager.js
+++ b/packages/dmn-js-shared/src/base/Manager.js
@@ -403,14 +403,15 @@ export default class Manager {
     // active view has changed OR
     // number of views has changed OR
     // not all views equal
-    var activeViewChanged = !viewsEqual(activeView, newActiveView),
-        viewsChanged =
-          views.length !== newViews.length
-          || !every(newViews, function(newView) {
-            return find(views, function(view) {
-              return viewsEqual(view, newView);
-            });
+    var activeViewChanged = !viewsEqual(activeView, newActiveView)
+      || viewNameChanged(activeView, newActiveView);
+
+    var viewsChanged = views.length !== newViews.length
+        || !every(newViews, function(newView) {
+          return find(views, function(view) {
+            return viewsEqual(view, newView) && !viewNameChanged(view, newView);
           });
+        });
 
     this._activeView = newActiveView;
     this._views = newViews;
@@ -630,9 +631,12 @@ function viewsEqual(a, b) {
     return false;
   }
 
-  // compare by element OR element ID equality AND element name equality
-  return (a.element === b.element || a.id === b.id)
-    && a.name === b.name;
+  // compare by element OR element ID equality
+  return a.element === b.element || a.id === b.id;
+}
+
+function viewNameChanged(a, b) {
+  return !a || !b || a.name !== b.name;
 }
 
 function safeExecute(viewer, method) {

--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -248,19 +248,29 @@ describe('Manager', function() {
           // given
           var manager = new TestViewer();
 
-          // when
-          manager.importXML(diagramXML);
-
           manager.once('import.done', function() {
+            const viewsChangedSpy = sinon.spy(manager, '_viewsChanged');
 
-            const spy = sinon.spy(manager, '_viewsChanged');
+            const dishDecisionView = manager.getViews().find(({ id }) => {
+              return id === 'dish-decision';
+            });
 
-            // recompute views without actual change
+            manager.open(dishDecisionView);
+
+            // assume
+            expect(manager.getActiveView().id).to.equal('dish-decision');
+
+            // when
             manager._updateViews();
 
             // then
-            expect(spy).not.to.have.been.called;
+            expect(viewsChangedSpy).to.have.been.called;
+
+            expect(manager.getActiveView().id).to.equal('dish-decision');
+            expect(manager.getViews()).to.length(4);
           });
+
+          manager.importXML(diagramXML);
         });
 
 
@@ -269,21 +279,31 @@ describe('Manager', function() {
           // given
           var manager = new TestViewer();
 
-          manager.importXML(diagramXML);
-
           manager.once('import.done', function() {
+            const viewsChangedSpy = sinon.spy(manager, '_viewsChanged');
 
-            const spy = sinon.spy(manager, '_viewsChanged');
+            const dishDecisionView = manager.getViews().find(({ id }) => {
+              return id === 'dish-decision';
+            });
+
+            manager.open(dishDecisionView);
+
+            // assume
+            expect(manager.getActiveView().id).to.equal('dish-decision');
 
             // when
-            manager.getViews()[ 0 ].element.name = 'Foo';
+            dishDecisionView.element.name = 'Foo';
 
-            // recompute views
             manager._updateViews();
 
             // then
-            expect(spy).to.have.been.called;
+            expect(viewsChangedSpy).to.have.been.called;
+
+            expect(manager.getActiveView().id).to.equal('dish-decision');
+            expect(manager.getViews()).to.length(4);
           });
+
+          manager.importXML(diagramXML);
         });
 
       });


### PR DESCRIPTION
Fixes a bug introduced by #523 
Closes #528 
