### PR TITLE
feat(decision-table/head): display FEEL as default expression language

### DIFF
--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCellContextMenu.js
@@ -87,7 +87,9 @@ export default class InputCellContextMenu extends Component {
 
     return (
       <InputEditor
-        expressionLanguage={ this.getValue('expressionLanguage') }
+        expressionLanguage={
+          this.getValue('expressionLanguage') || defaultLanguage.value
+        }
         expressionLanguages={ expressionLanguages }
         defaultExpressionLanguage={ defaultLanguage }
         inputVariable={ this.getValue('inputVariable') }

--- a/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorCellSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorCellSpec.js
@@ -90,6 +90,17 @@ describe('decision-table-head/editor - input', function() {
   }));
 
 
+  it('should display FEEL per default', function() {
+
+    // given
+    const editorEl = openEditor('input1');
+    const inputEl = getControl('.ref-language input', editorEl);
+
+    // then
+    expect(inputEl).to.have.property('value', 'feel');
+  });
+
+
   describe('should edit input variable', function() {
 
     beforeEach(function() {

--- a/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorCellSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-table-head/editor/input/InputEditorCellSpec.js
@@ -90,60 +90,6 @@ describe('decision-table-head/editor - input', function() {
   }));
 
 
-  describe('should transform to script', function() {
-
-    beforeEach(function() {
-      openEditor('input1');
-    });
-
-
-    it('via input', inject(function(elementRegistry) {
-
-      // given
-      const inputBo = elementRegistry.get('input1').businessObject;
-
-      const inputEl = getControl('.ref-text', testContainer);
-
-      inputEl.focus();
-
-      // when
-      triggerInputEvent(inputEl, 'foo<br>bar<br>');
-
-      // then
-      expect(inputBo.inputExpression.text).to.equal('foo\nbar');
-      expect(inputBo.inputExpression.expressionLanguage).to.equal('feel');
-    }));
-  });
-
-
-  describe('should transform back to expression', function() {
-
-    beforeEach(function() {
-      openEditor('input1');
-    });
-
-
-    it('via input', inject(function(elementRegistry) {
-
-      // given
-      const inputBo = elementRegistry.get('input1').businessObject;
-
-      const inputEl = getControl('.ref-text', testContainer);
-
-      inputEl.focus();
-
-      // when
-      triggerInputEvent(inputEl, 'foo<br>bar<br>');
-      triggerInputEvent(inputEl, 'foo');
-
-      // then
-      expect(inputBo.inputExpression.text).to.equal('foo');
-      expect(inputBo.inputExpression.expressionLanguage).not.to.exist;
-    }));
-
-  });
-
-
   describe('should edit input variable', function() {
 
     beforeEach(function() {


### PR DESCRIPTION
__Which issue does this PR address?__

This popped up on Slack as part of general feedback. The PR makes sure that we display default expression language (FEEL) when none is set.

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
