### PR TITLE
Open input/output editing at correct position

### DIFF
--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/InputEditingProvider.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/InputEditingProvider.js
@@ -33,7 +33,8 @@ export default class InputCellProvider {
 
       contextMenu.open({
         x: left,
-        y: top
+        y: top,
+        align: 'bottom-right'
       }, {
         contextMenuType: 'input-edit',
         input

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/OutputEditingProvider.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/OutputEditingProvider.js
@@ -36,7 +36,8 @@ export default class OutputEditingProvider {
 
       contextMenu.open({
         x: left,
-        y: top
+        y: top,
+        align: 'bottom-right'
       }, {
         contextMenuType: 'output-edit',
         output,


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/1869

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
