### PR TITLE
Hide InputSelect options on global mousedown event

### DIFF
--- a/packages/dmn-js-shared/src/components/InputSelect.js
+++ b/packages/dmn-js-shared/src/components/InputSelect.js
@@ -30,7 +30,7 @@ export default class InputSelect extends Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onGlobalClick);
+    document.addEventListener('mousedown', this.onGlobalClick);
     document.addEventListener('focusin', this.onFocusChanged);
 
     this.keyboard.addListener(this.onKeyboard);
@@ -38,7 +38,7 @@ export default class InputSelect extends Component {
 
   componentWillUnmount() {
     document.removeEventListener('focusin', this.onFocusChanged);
-    document.removeEventListener('click', this.onGlobalClick);
+    document.removeEventListener('mousedown', this.onGlobalClick);
 
     this.keyboard.removeListener(this.onKeyboard);
 

--- a/packages/dmn-js-shared/test/spec/components/InputSelectSpec.js
+++ b/packages/dmn-js-shared/test/spec/components/InputSelectSpec.js
@@ -175,6 +175,30 @@ describe('components/InputSelect', function() {
     });
 
 
+    it('should hide options on mousedown event outside', function() {
+
+      // given
+      const renderedTree = renderIntoDocument(
+        <DiContainer injector={ injector }>
+          <InputSelect
+            options={ OPTIONS } />
+        </DiContainer>
+      );
+
+      const input = findRenderedDOMElementWithClass(renderedTree, 'dms-input');
+
+      triggerClick(input);
+
+      // when
+      triggerMouseEvent(testContainer, 'mousedown');
+
+      // then
+      const options = findRenderedDOMElementWithClass(renderedTree, 'options');
+
+      expect(options).to.not.exist;
+    });
+
+
     describe('keyboard controls', function() {
 
       const ARROW_DOWN_KEY = 40;


### PR DESCRIPTION
Closes #559

__Definition of Done__

* [x] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [x] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [x] passes Continuous Integration checks
* [x] available as feature branch on GitHub
  * [x] contains the cleaned up commit history
  * [x] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [x] a single commit closes the issue via Closes #issuenr
