### PR TITLE
Use absolute position for InputSelect options

### DIFF
--- a/packages/dmn-js-shared/assets/css/dmn-js-shared.css
+++ b/packages/dmn-js-shared/assets/css/dmn-js-shared.css
@@ -200,7 +200,7 @@ h4.dms-heading {
 }
 
 .dms-select-options {
-  position: fixed;
+  position: absolute;
   background-color: var(--select-options-background-color);
   border: solid 1px var(--select-options-border-color);
   border-radius: 2px;

--- a/packages/dmn-js-shared/src/components/InputSelect.js
+++ b/packages/dmn-js-shared/src/components/InputSelect.js
@@ -74,13 +74,27 @@ export default class InputSelect extends Component {
       return;
     }
 
-    const { top, left, width, height } = this.inputNode.getBoundingClientRect();
+    const optionsBounds = this.getOptionsBounds();
 
-    assign(this._portalEl.style, {
-      top: `${top + height}px`,
+    assign(this._portalEl.style, optionsBounds);
+  }
+
+  getOptionsBounds() {
+    const container = this.renderer.getContainer();
+    const { top: containerTop, left: containerLeft } = container.getBoundingClientRect();
+
+    const {
+      top: inputTop, left: inputLeft, width, height
+    } = this.inputNode.getBoundingClientRect();
+
+    const top = inputTop + height - containerTop + container.scrollTop;
+    const left = inputLeft - containerLeft + container.scrollLeft;
+
+    return {
+      top: `${top}px`,
       left: `${left}px`,
       width: `${width}px`
-    });
+    };
   }
 
   addPortalEl() {

--- a/packages/dmn-js-shared/test/spec/components/InputSelectSpec.js
+++ b/packages/dmn-js-shared/test/spec/components/InputSelectSpec.js
@@ -132,6 +132,34 @@ describe('components/InputSelect', function() {
     });
 
 
+    it('should show options with correct position', function() {
+
+      // given
+      const renderedTree = renderIntoDocument(
+        <DiContainer injector={ injector }>
+          <InputSelect
+            options={ OPTIONS } />
+        </DiContainer>
+      );
+      const container = injector.get('renderer').getContainer();
+      container.style.transform = 'translate(2px)';
+
+      const inputSelect =
+        findRenderedDOMElementWithClass(renderedTree, 'dms-input-select');
+
+      // when
+      triggerClick(inputSelect);
+
+      // then
+      const options = findRenderedDOMElementWithClass(renderedTree, 'options');
+      const inputSelectBounds = inputSelect.getBoundingClientRect();
+      const optionsBounds = options.getBoundingClientRect();
+
+      expect(optionsBounds.top).to.eql(inputSelectBounds.height + inputSelectBounds.top);
+      expect(optionsBounds.left).to.eql(inputSelectBounds.left);
+    });
+
+
     it('should hide options on blur', function() {
 
       // given


### PR DESCRIPTION
Previously, options were positioned using `position: fixed`.
However, this can lead to bugs as element can be positioned thus
either relatively to the viewport (intended) or some other container
in which dmn-js is rendered. The latter happens if container
has `transform`, `filter` or `perspective` set to other value
than `none`. This is exactly what we use in order to display
bpmn.io logo all the time in correct place of decision table
and literal expression views.

Cf. https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed

Closes #589

__Definition of Done__

* [ ] corresponds to [the design principles](https://github.com/bpmn-io/design-principles)
* [ ] corresponds to [the code standards](https://github.com/bpmn-io/bpmn-js/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request)
* [ ] passes Continuous Integration checks
* [ ] available as feature branch on GitHub
  * [ ] contains the cleaned up commit history
  * [ ] commit messages satisfy our [commit message guidelines](https://www.conventionalcommits.org/)
  * [ ] a single commit closes the issue via Closes #issuenr
