### PR TITLE
Fix Association Parent Update (Again)

### DIFF
--- a/packages/dmn-js-drd/src/features/modeling/DrdUpdater.js
+++ b/packages/dmn-js-drd/src/features/modeling/DrdUpdater.js
@@ -151,6 +151,10 @@ export default function DrdUpdater(
         newTarget = context.newTarget,
         newTargetBo = newTarget.businessObject;
 
+    if (is(connectionBo, 'dmn:Association')) {
+      return;
+    }
+
     self.updateSemanticParent(connectionBo, newTargetBo);
   }, true);
 
@@ -159,6 +163,10 @@ export default function DrdUpdater(
         connectionBo = connection.businessObject,
         oldTarget = context.oldTarget,
         oldTargetBo = oldTarget.businessObject;
+
+    if (is(connectionBo, 'dmn:Association')) {
+      return;
+    }
 
     self.updateSemanticParent(connectionBo, oldTargetBo);
   }, true);

--- a/packages/dmn-js-drd/test/spec/features/modeling/DrdUpdaterSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/DrdUpdaterSpec.js
@@ -131,76 +131,134 @@ describe('features/modeling - DrdUpdater', function() {
     ));
 
 
-    it('should update parent when information requirement is created', inject(
-      function(elementRegistry, modeling) {
+    describe('connections', function() {
 
-        // given
-        var decision1 = elementRegistry.get('Decision_2'),
-            decision2 = elementRegistry.get('Decision_3');
+      describe('information requirement', function() {
 
-        // when
-        var informationRequirement = modeling.connect(decision1, decision2),
-            informationRequirementBo = informationRequirement.businessObject;
+        it('should update parent when information requirement is created', inject(
+          function(elementRegistry, modeling) {
 
-        // then
-        expect(informationRequirementBo.$parent).to.eql(decision2.businessObject);
-      }
-    ));
+            // given
+            var decision1 = elementRegistry.get('Decision_2'),
+                decision2 = elementRegistry.get('Decision_3');
 
+            // when
+            var informationRequirement = modeling.connect(decision1, decision2),
+                informationRequirementBo = informationRequirement.businessObject;
 
-    it('should update parent when information requirement is removed', inject(
-      function(elementRegistry, modeling) {
-
-        // given
-        var informationRequirement = elementRegistry.get('InformationRequirement_1'),
-            informationRequirementBo = informationRequirement.businessObject;
-
-        // when
-        modeling.removeConnection(informationRequirement);
-
-        // then
-        expect(informationRequirementBo.$parent).to.be.null;
-      }
-    ));
+            // then
+            expect(informationRequirementBo.$parent).to.eql(decision2.businessObject);
+          }
+        ));
 
 
-    it('should update parent when association is created', inject(
-      function(elementRegistry, modeling) {
+        it('should update parent when information requirement is removed', inject(
+          function(elementRegistry, modeling) {
 
-        // given
-        var definitions = elementRegistry.get('Definitions_1'),
-            definitionsBo = definitions.businessObject,
-            textAnnotation = elementRegistry.get('TextAnnotation_1'),
-            decision = elementRegistry.get('Decision_3');
+            // given
+            var informationRequirement = elementRegistry.get('InformationRequirement_1'),
+                informationRequirementBo = informationRequirement.businessObject;
 
-        // when
-        var association = modeling.connect(textAnnotation, decision),
-            associationBo = association.businessObject;
+            // when
+            modeling.removeConnection(informationRequirement);
 
-        // then
-        expect(associationBo.$parent).to.eql(definitionsBo);
-        expect(definitionsBo.get('artifact')).to.include(associationBo);
-      }
-    ));
+            // then
+            expect(informationRequirementBo.$parent).to.be.null;
+          }
+        ));
+
+      });
 
 
-    it('should update parent when association is removed', inject(
-      function(elementRegistry, modeling) {
+      describe('association', function() {
 
-        // given
-        var definitions = elementRegistry.get('Definitions_1'),
-            definitionsBo = definitions.businessObject,
-            association = elementRegistry.get('Association_1'),
-            associationBo = association.businessObject;
+        it('should update parent when association is created', inject(
+          function(elementRegistry, modeling) {
 
-        // when
-        modeling.removeConnection(association);
+            // given
+            var definitions = elementRegistry.get('Definitions_1'),
+                definitionsBo = definitions.businessObject,
+                textAnnotation = elementRegistry.get('TextAnnotation_1'),
+                decision = elementRegistry.get('Decision_3');
 
-        // then
-        expect(associationBo.$parent).to.be.null;
-        expect(definitionsBo.get('artifact')).to.not.include(associationBo);
-      }
-    ));
+            // when
+            var association = modeling.connect(textAnnotation, decision),
+                associationBo = association.businessObject;
+
+            // then
+            expect(associationBo.$parent).to.eql(definitionsBo);
+            expect(definitionsBo.get('artifact')).to.include(associationBo);
+          }
+        ));
+
+
+        describe('should not update parent when association is reconnected', function() {
+
+          it('<do>', inject(
+            function(elementRegistry, modeling) {
+
+              // given
+              var definitions = elementRegistry.get('Definitions_1'),
+                  definitionsBo = definitions.businessObject,
+                  association = elementRegistry.get('Association_1'),
+                  decision = elementRegistry.get('Decision_2'),
+                  associationBo = association.businessObject;
+
+              // when
+              modeling.reconnectStart(association, decision, getMid(decision));
+
+              // then
+              expect(associationBo.$parent).to.eql(definitionsBo);
+              expect(definitionsBo.get('artifact')).to.include(associationBo);
+            }
+          ));
+
+
+          it('<undo>', inject(
+            function(commandStack, elementRegistry, modeling) {
+
+              // given
+              var definitions = elementRegistry.get('Definitions_1'),
+                  definitionsBo = definitions.businessObject,
+                  association = elementRegistry.get('Association_1'),
+                  decision = elementRegistry.get('Decision_2'),
+                  associationBo = association.businessObject;
+
+              modeling.reconnectStart(association, decision, getMid(decision));
+
+              // when
+              commandStack.undo();
+
+              // then
+              expect(associationBo.$parent).to.eql(definitionsBo);
+              expect(definitionsBo.get('artifact')).to.include(associationBo);
+            }
+          ));
+
+        });
+
+
+        it('should update parent when association is removed', inject(
+          function(elementRegistry, modeling) {
+
+            // given
+            var definitions = elementRegistry.get('Definitions_1'),
+                definitionsBo = definitions.businessObject,
+                association = elementRegistry.get('Association_1'),
+                associationBo = association.businessObject;
+
+            // when
+            modeling.removeConnection(association);
+
+            // then
+            expect(associationBo.$parent).to.be.null;
+            expect(definitionsBo.get('artifact')).to.not.include(associationBo);
+          }
+        ));
+
+      });
+
+    });
 
   });
 

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/IdChangeBehaviorSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/IdChangeBehaviorSpec.js
@@ -19,7 +19,7 @@ describe('IdChangeBehavior', function() {
 
 
   it('should update IDs on decision ID change', inject(
-    function(elementRegistry,modeling) {
+    function(elementRegistry, modeling) {
 
       // given
       const decision = elementRegistry.get('guestCount'),
@@ -35,7 +35,7 @@ describe('IdChangeBehavior', function() {
 
 
   it('should update association sourceRef on source ID change', inject(
-    function(elementRegistry,modeling) {
+    function(elementRegistry, modeling) {
 
       // given
       const source = elementRegistry.get('dayType_id'),
@@ -51,7 +51,7 @@ describe('IdChangeBehavior', function() {
 
 
   it('should update association targetRef on target ID change', inject(
-    function(elementRegistry,modeling) {
+    function(elementRegistry, modeling) {
 
       // given
       const target = elementRegistry.get('annotation_1'),

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/replace-element-behavior.dmn
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/replace-element-behavior.dmn
@@ -11,7 +11,7 @@
     <informationRequirement id="temperature_ir">
       <requiredDecision href="#foobar"/>
     </informationRequirement>
-  </decision>`
+  </decision>
   <decision id="guestCount" name="Guest Count" />
   <textAnnotation id="textAnnotation">
     <text>foobar</text>


### PR DESCRIPTION
The issue is that when replacing the decision the association's parent from the model's perspective is changed to the text annotation. In the case of information requirements and such the parent is indeed the target element. Not in this case since the association is an artifact.

This issue was fixed before (https://github.com/bpmn-io/dmn-js/commit/90a7952153d3bfc87ddd6e5ec75b167326d6d231#diff-a42b136569b62592b63126d0bfe523df9cfd77884dfd10741252ceead428e185R265) but then broken again (https://github.com/bpmn-io/dmn-js/commit/853eea1146af68ba18f6b2e8d74dbf3446c5c7a0#).

So we're fixing it again. ♻️ 

Related to camunda/camunda-modeler#1763
Related to camunda/camunda-modeler#1814
Related to camunda/camunda-modeler#1874
Related to https://github.com/camunda/camunda-modeler/issues/2052