### PR TITLE
feat(connect-tool) : enable for text annotation

### DIFF
--- a/packages/dmn-js-drd/src/features/context-pad/ContextPadProvider.js
+++ b/packages/dmn-js-drd/src/features/context-pad/ContextPadProvider.js
@@ -235,6 +235,22 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     });
   }
 
+  if (is(businessObject, 'dmn:TextAnnotation')) {
+    assign(actions, {
+      'connect': {
+        group: 'connect',
+        className: 'dmn-icon-connection-multi',
+        title: translate(
+          'Connect using association'
+        ),
+        action: {
+          click: startConnect,
+          dragstart: startConnect
+        }
+      }
+    });
+  }
+
   if (!popupMenu.isEmpty(element, 'dmn-replace')) {
 
     // Replace menu entry

--- a/packages/dmn-js-drd/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -257,6 +257,7 @@ describe('features - context-pad', function() {
     it('should provide entries for TextAnnotation', inject(function() {
 
       expectContextPadEntries('TextAnnotation_1t4zaz9', [
+        'connect',
         'delete'
       ]);
     }));


### PR DESCRIPTION
related to https://github.com/camunda/camunda-modeler/issues/2042

Modified :
- ContextPadProvider.js for enabling connect tool for text annotation.
- ContextPadProviderSpec.js for tests.
- for tooltip text i put : "Connect using association" when mouse hover the connect tool

