### PR TITLE
Allow to add output if dmn:input does not exist

### DIFF
--- a/packages/dmn-js-decision-table/src/features/editor-actions/DecisionTableEditorActions.js
+++ b/packages/dmn-js-decision-table/src/features/editor-actions/DecisionTableEditorActions.js
@@ -115,7 +115,8 @@ export default class DecisionTableEditorActions {
         const root = sheet.getRoot(),
               businessObject = root.businessObject;
 
-        const { input, output } = businessObject;
+        const input = businessObject.get('input'),
+              output = businessObject.get('output');
 
         return modeling.addCol(
           { type: 'dmn:OutputClause' },

--- a/packages/dmn-js-decision-table/test/spec/features/editor-actions/EditorActionsSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/editor-actions/EditorActionsSpec.js
@@ -1,6 +1,7 @@
 import { bootstrapModeler, inject } from 'test/helper';
 
 import simpleXML from '../../simple.dmn';
+import noInputsXML from '../../no-inputs.dmn';
 
 import CoreModule from 'src/core';
 import EditorActionsModule from 'src/features/editor-actions';
@@ -649,6 +650,35 @@ describe('features/editor-actions', function() {
     expect(currentSelection.id).to.equal('inputEntry7');
   }));
 
+
+
+  describe('missing inputs', function() {
+
+    beforeEach(bootstrapModeler(noInputsXML, {
+      modules: [
+        CoreModule,
+        EditorActionsModule,
+        ModelingModule,
+        RulesEditorModule
+      ]
+    }));
+
+    it('should add output if inputs are missing', inject(function(sheet, editorActions) {
+
+      // given
+      const root = sheet.getRoot();
+      const existingOutput = root.cols[0];
+
+      // when
+      const newOutput = editorActions.trigger('addOutput');
+
+      // then
+      expectOrder(root.cols, [
+        existingOutput,
+        newOutput
+      ]);
+    }));
+  });
 });
 
 


### PR DESCRIPTION
Previously the editor would fail to add an output if no input was given in the DMN table. This PR fixes the behavior.