### PR TITLE
Correct import xml event lifecycle

### DIFF
--- a/packages/dmn-js-shared/src/base/Manager.js
+++ b/packages/dmn-js-shared/src/base/Manager.js
@@ -109,7 +109,7 @@ export default class Manager {
       }
 
       if (err || !options.open) {
-        this._emit('import.done', { error: err, warmings: parseWarnings });
+        this._emit('import.done', { error: err, warnings: parseWarnings });
 
         return done(err, parseWarnings);
       }
@@ -117,7 +117,12 @@ export default class Manager {
       var view = this._activeView || this._getInitialView(this._views);
 
       if (!view) {
-        return done(new Error('no displayable contents'));
+        err = new Error('no displayable contents');
+
+        this._emit('import.done',
+          { error: err, warnings: parseWarnings });
+
+        return done(err);
       }
 
       this.open(view, (err, warnings) => {

--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -365,8 +365,8 @@ describe('Manager', function() {
     });
 
 
-    it('should emit <import.parse.start> and' +
-      ' <import.parse.complete> when no displayable contents',
+    it('should emit <import.parse.start>,' +
+      ' <import.parse.complete> and <import.done> when no displayable contents',
     function(done) {
 
       // given
@@ -394,7 +394,7 @@ describe('Manager', function() {
       var err;
 
       manager.on([
-        'import.parse.complete'
+        'import.done'
       ], function(e) {
 
         err = e.error;
@@ -406,13 +406,17 @@ describe('Manager', function() {
         // then
         expect(e).to.exist;
         expect(e).to.be.an.instanceOf(Error);
+        expect(e.message).to.match(/no displayable contents/);
 
         expect(events).to.eql([
           [ 'import.parse.start', [ 'xml' ] ],
-          [ 'import.parse.complete', ['error', 'definitions', 'context' ] ]
+          [ 'import.parse.complete', ['error', 'definitions', 'context' ] ],
+          [ 'import.done', ['error', 'warnings' ] ]
         ]);
 
-        expect(err).to.be.undefined;
+        expect(err).to.exist;
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.match(/no displayable contents/);
 
         done();
       });
@@ -482,7 +486,7 @@ describe('Manager', function() {
         expect(events).to.eql([
           [ 'import.parse.start', [ 'xml' ] ],
           [ 'import.parse.complete', ['error', 'definitions', 'context' ] ],
-          [ 'import.done', ['error', 'warmings' ] ]
+          [ 'import.done', ['error', 'warnings' ] ]
         ]);
 
         expect(err).to.exist;

--- a/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
+++ b/packages/dmn-js-shared/test/spec/base/ManagerSpec.js
@@ -6,6 +6,7 @@ import TestView from './TestView';
 
 import { spy } from 'sinon';
 
+
 import { find } from 'min-dash';
 
 class TestViewer extends Manager {
@@ -364,6 +365,60 @@ describe('Manager', function() {
     });
 
 
+    it('should emit <import.parse.start> and' +
+      ' <import.parse.complete> when no displayable contents',
+    function(done) {
+
+      // given
+      var manager = new Manager();
+
+      var events = [];
+
+      manager.on([
+        'import.parse.start',
+        'import.parse.complete',
+        'import.render.start',
+        'import.render.complete',
+        'import.done'
+      ], function(e) {
+
+        // log event type + event arguments
+        events.push([
+          e.type,
+          Object.keys(e).filter(function(key) {
+            return key !== 'type';
+          })
+        ]);
+      });
+
+      var err;
+
+      manager.on([
+        'import.parse.complete'
+      ], function(e) {
+
+        err = e.error;
+      });
+
+      // when
+      manager.importXML(diagramXML, function(e) {
+
+        // then
+        expect(e).to.exist;
+        expect(e).to.be.an.instanceOf(Error);
+
+        expect(events).to.eql([
+          [ 'import.parse.start', [ 'xml' ] ],
+          [ 'import.parse.complete', ['error', 'definitions', 'context' ] ]
+        ]);
+
+        expect(err).to.be.undefined;
+
+        done();
+      });
+    });
+
+
     it('should indicate broken XML', function(done) {
 
       // given
@@ -378,6 +433,64 @@ describe('Manager', function() {
         done();
       });
 
+    });
+
+
+    it('should emit <import.parse.start>, <import.parse.complete>' +
+      ' and <import.done> events with broken XML',
+    function(done) {
+
+      // given
+      var manager = new Manager();
+
+      var events = [];
+
+      manager.on([
+        'import.parse.start',
+        'import.parse.complete',
+        'import.render.start',
+        'import.render.complete',
+        'import.done'
+      ], function(e) {
+
+        // log event type + event arguments
+        events.push([
+          e.type,
+          Object.keys(e).filter(function(key) {
+            return key !== 'type';
+          })
+        ]);
+      });
+
+      var err;
+
+      manager.on([
+        'import.done'
+      ], function(e) {
+
+        err = e.error;
+      });
+
+      // when
+      manager.importXML('<foo&&', function(e) {
+
+        // then
+        expect(e).to.exist;
+        expect(e).to.be.an.instanceOf(Error);
+        expect(e.message).to.match(/unparsable content <foo&& detected/);
+
+        expect(events).to.eql([
+          [ 'import.parse.start', [ 'xml' ] ],
+          [ 'import.parse.complete', ['error', 'definitions', 'context' ] ],
+          [ 'import.done', ['error', 'warmings' ] ]
+        ]);
+
+        expect(err).to.exist;
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.message).to.match(/unparsable content <foo&& detected/);
+
+        done();
+      });
     });
 
   });


### PR DESCRIPTION
I spotted this missing testcoverage and inconsistency in the event lifecycle and wanted to clean it up prior to finishing the dmn-js promisification. This allows me to have a stable baseline for the promisification exercise.
