### PR TITLE
fix: correct inter-package imports

### DIFF
--- a/packages/dmn-js-decision-table/src/Viewer.js
+++ b/packages/dmn-js-decision-table/src/Viewer.js
@@ -22,11 +22,11 @@ import viewDrdModule from './features/view-drd';
 import PoweredByModule from './features/powered-by';
 
 /**
- * @typedef {import('../../dmn-js-shared/src/base/View).OpenResult} OpenResult
+ * @typedef {import('dmn-js-shared/lib/base/View).OpenResult} OpenResult
  */
 
 /**
- * @typedef {import('../../dmn-js-shared/src/base/View).OpenError} OpenError
+ * @typedef {import('dmn-js-shared/lib/base/View).OpenError} OpenError
  */
 
 

--- a/packages/dmn-js-drd/src/Viewer.js
+++ b/packages/dmn-js-drd/src/Viewer.js
@@ -25,15 +25,15 @@ import {
 
 import {
   wrapForCompatibility
-} from '../../dmn-js-shared/src/util/CompatibilityUtils';
+} from 'dmn-js-shared/lib/util/CompatibilityUtils';
 
 
 /**
- * @typedef {import('../../dmn-js-shared/src/base/View).OpenResult} OpenResult
+ * @typedef {import('dmn-js-shared/lib/base/View).OpenResult} OpenResult
  */
 
 /**
- * @typedef {import('../../dmn-js-shared/src/base/View).OpenError} OpenError
+ * @typedef {import('dmn-js-shared/lib/base/View).OpenError} OpenError
  */
 
 

--- a/packages/dmn-js-literal-expression/src/Viewer.js
+++ b/packages/dmn-js-literal-expression/src/Viewer.js
@@ -17,11 +17,11 @@ import TextareaModule from './features/textarea';
 import ViewDrdModule from './features/view-drd';
 
 /**
- * @typedef {import('../../dmn-js-shared/src/base/View).OpenResult} OpenResult
+ * @typedef {import('dmn-js-shared/lib/base/View).OpenResult} OpenResult
  */
 
 /**
- * @typedef {import('../../dmn-js-shared/src/base/View).OpenError} OpenError
+ * @typedef {import('dmn-js-shared/lib/base/View).OpenError} OpenError
  */
 
 

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: correctly use inter-package imports ([45beb23](https://github.com/bpmn-io/dmn-js/pull/643/commits/45beb231bbe9968cb1ec5e8c4c3da43059307234))
+
 ## 11.0.0
 
 * `FEAT`: make `#fromXML`, `#saveXML`, `#saveSVG`, and `#open` APIs awaitable ([#514](https://github.com/bpmn-io/dmn-js/issues/514))


### PR DESCRIPTION
Correct inter-package imports (same way we already do it, for example [here](https://github.com/bpmn-io/dmn-js/blob/develop/packages/dmn-js-decision-table/src/Editor.js#L15))
