### PR TITLE
refactor(dmn-js-decision-table): rename class

### DIFF
--- a/packages/dmn-js-decision-table/src/features/decision-rules/components/DecisionRulesCellEditorComponent.js
+++ b/packages/dmn-js-decision-table/src/features/decision-rules/components/DecisionRulesCellEditorComponent.js
@@ -9,7 +9,7 @@ import EditableComponent from 'dmn-js-shared/lib/components/EditableComponent';
 import { Cell } from 'table-js/lib/components';
 
 
-export default class DecisionRulesEditorCellComponent extends Component {
+export default class DecisionRulesCellEditorComponent extends Component {
 
   constructor(props, context) {
     super(props, context);


### PR DESCRIPTION
Since this is a default export, it is not so important what the class is called here. However, for consistency and maintainability reasons, I would suggest naming this class also as it is called in the other components. In addition, it then corresponds to the file name.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
