### PR TITLE
style: use font variables

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
@@ -36,12 +36,13 @@
   --view-drd-button-border-color: var(--color-cccccc);
   --view-drd-button-color: var(--color-444444);
   --view-drd-button-hover-background-color: var(--color-f6f6f6);
+  --decision-table-font-family: 'Arial', sans-serif;
 
   width: 100%;
   height: 100%;
   overflow: hidden;
   position: relative;
-  font-family: 'Arial', sans-serif;
+  font-family: var(--decision-table-font-family);
   font-size: 14px;
   color: var(--table-color);
   max-height: 100%;

--- a/packages/dmn-js-drd/assets/css/dmn-js-drd.css
+++ b/packages/dmn-js-drd/assets/css/dmn-js-drd.css
@@ -4,6 +4,7 @@
   --dmn-definitions-focus-border-color: var(--color-aaaaaa);
   --drill-down-overlay-background-color: var(--blue-base-65);
   --drill-down-overlay-color: var(--color-ffffff);
+  --drd-font-family-monospace: monospace;
 
   width: 100%;
   height: 100%;
@@ -43,7 +44,7 @@
 }
 
 .dmn-definitions .dmn-definitions-id {
-  font-family: monospace;
+  font-family: var(--drd-font-family-monospace);
   margin-top: 2px;
   padding: 3px;
 }

--- a/packages/dmn-js-literal-expression/assets/css/dmn-js-literal-expression.css
+++ b/packages/dmn-js-literal-expression/assets/css/dmn-js-literal-expression.css
@@ -15,8 +15,10 @@
   --view-drd-button-border-color: var(--color-cccccc);
   --view-drd-button-color: var(--color-444444);
   --view-drd-button-hover-background-color: var(--color-f6f6f6);
+  --literal-expression-font-family: 'Arial', sans-serif;
+  --literal-expression-font-family-monospace: monospace;
 
-  font-family: 'Arial', sans-serif;
+  font-family: var(--literal-expression-font-family);
   position: relative;
   color: var(--literal-expression-color);
   width: 100%;
@@ -96,7 +98,7 @@
 .dmn-literal-expression-container .textarea {
   box-sizing: border-box;
   width: 100%;
-  font-family: monospace;
+  font-family: var(--literal-expression-font-family-monospace);
   border: 1px solid var(--textarea-border-color);
   border-bottom-width: 1px;
   white-space: pre;

--- a/packages/dmn-js-shared/assets/css/dmn-js-shared.css
+++ b/packages/dmn-js-shared/assets/css/dmn-js-shared.css
@@ -126,6 +126,7 @@ h4.dms-heading {
   border: 1px solid var(--input-border-color);
   background: none;
   font-size: 14px;
+  font-family: inherit;
   color: var(--input-color);
   min-height: 26px;
 }


### PR DESCRIPTION
Ensures the font can be easily overridden.

Related to https://github.com/camunda/camunda-modeler/issues/2458

![image](https://user-images.githubusercontent.com/9433996/138286966-6b19ab6a-25af-414c-9a90-5ddb8befec0b.png)

