### PR TITLE
feat: remove Camunda Platform expression languages

### DIFF
--- a/packages/dmn-js-decision-table/test/spec/features/decision-rules/DecisionRulesEditorSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/decision-rules/DecisionRulesEditorSpec.js
@@ -17,6 +17,26 @@ import ModelingModule from 'src/features/modeling';
 import DecisionRulesModule from 'src/features/decision-rules';
 import DecisionRulesEditorModule from 'src/features/decision-rules/editor';
 
+const CUSTOM_EXPRESSION_LANGUAGES = [{
+  label: 'FEEL',
+  value: 'feel'
+}, {
+  label: 'JUEL',
+  value: 'juel'
+}, {
+  label: 'JavaScript',
+  value: 'javascript'
+}, {
+  label: 'Groovy',
+  value: 'groovy'
+}, {
+  label: 'Python',
+  value: 'python'
+}, {
+  label: 'JRuby',
+  value: 'jruby'
+}];
+
 
 describe('features/decision-rules', function() {
 
@@ -81,6 +101,9 @@ describe('features/decision-rules', function() {
     describe('no default expression language', function() {
 
       beforeEach(bootstrapModeler(languageExpressionXML, {
+        expressionLanguages: {
+          options: CUSTOM_EXPRESSION_LANGUAGES
+        },
         modules: [
           CoreModule,
           ModelingModule,
@@ -174,6 +197,9 @@ describe('features/decision-rules', function() {
     describe('configured default expression language', function() {
 
       beforeEach(bootstrapModeler(languageExpressionXML, {
+        expressionLanguages: {
+          options: CUSTOM_EXPRESSION_LANGUAGES
+        },
         modules: [
           CoreModule,
           ModelingModule,

--- a/packages/dmn-js-decision-table/test/spec/features/expression-language/ExpressionLanguageSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/expression-language/ExpressionLanguageSpec.js
@@ -20,9 +20,33 @@ import DecisionRulesEditorModule from 'src/features/decision-rules/editor';
 import KeyboardModule from 'src/features/keyboard';
 
 
+const CUSTOM_EXPRESSION_LANGUAGES = [{
+  label: 'FEEL',
+  value: 'feel'
+}, {
+  label: 'JUEL',
+  value: 'juel'
+}, {
+  label: 'JavaScript',
+  value: 'javascript'
+}, {
+  label: 'Groovy',
+  value: 'groovy'
+}, {
+  label: 'Python',
+  value: 'python'
+}, {
+  label: 'JRuby',
+  value: 'jruby'
+}];
+
+
 describe('expression language', function() {
 
   beforeEach(bootstrapModeler(simpleXML, {
+    expressionLanguages: {
+      options: CUSTOM_EXPRESSION_LANGUAGES
+    },
     modules: [
       ContextMenuModule,
       CoreModule,

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
@@ -22,9 +22,33 @@ import CoreModule from 'src/core';
 import ModelingModule from 'src/features/modeling';
 
 
+const CUSTOM_EXPRESSION_LANGUAGES = [{
+  label: 'FEEL',
+  value: 'feel'
+}, {
+  label: 'JUEL',
+  value: 'juel'
+}, {
+  label: 'JavaScript',
+  value: 'javascript'
+}, {
+  label: 'Groovy',
+  value: 'groovy'
+}, {
+  label: 'Python',
+  value: 'python'
+}, {
+  label: 'JRuby',
+  value: 'jruby'
+}];
+
+
 describe('literal expression properties editor', function() {
 
   beforeEach(bootstrapModeler(literalExpressionXML, {
+    expressionLanguages: {
+      options: CUSTOM_EXPRESSION_LANGUAGES
+    },
     modules: [
       CoreModule,
       LiteralExpressionPropertiesEditorModule,

--- a/packages/dmn-js-shared/src/features/expression-languages/ExpressionLanguages.js
+++ b/packages/dmn-js-shared/src/features/expression-languages/ExpressionLanguages.js
@@ -7,21 +7,6 @@ import {
 const EXPRESSION_LANGUAGE_OPTIONS = [{
   label: 'FEEL',
   value: 'feel'
-}, {
-  label: 'JUEL',
-  value: 'juel'
-}, {
-  label: 'JavaScript',
-  value: 'javascript'
-}, {
-  label: 'Groovy',
-  value: 'groovy'
-}, {
-  label: 'Python',
-  value: 'python'
-}, {
-  label: 'JRuby',
-  value: 'jruby'
 }];
 
 /**

--- a/packages/dmn-js-shared/test/spec/features/expression-languages/ExpressionLanguagesSpec.js
+++ b/packages/dmn-js-shared/test/spec/features/expression-languages/ExpressionLanguagesSpec.js
@@ -6,6 +6,11 @@ import ExpressionLanguagesModule from 'lib/features/expression-languages';
 const DEFAULT_OPTIONS = [{
   label: 'FEEL',
   value: 'feel'
+}];
+
+const CUSTOM_OPTIONS = [{
+  label: 'FEEL',
+  value: 'feel'
 }, {
   label: 'JUEL',
   value: 'juel'
@@ -65,6 +70,7 @@ describe('ExpressionLanguages', function() {
       // given
       const expressionLanguages = createExpressionLanguages({
         expressionLanguages: {
+          options: CUSTOM_OPTIONS,
           defaults: {
             editor: 'javascript',
             inputCell: 'jruby'
@@ -92,6 +98,9 @@ describe('ExpressionLanguages', function() {
 
       // given
       const expressionLanguages = createExpressionLanguages({
+        expressionLanguages: {
+          options: CUSTOM_OPTIONS,
+        },
         defaultInputExpressionLanguage: 'jruby',
         defaultOutputExpressionLanguage: 'javascript'
       });
@@ -131,10 +140,9 @@ describe('ExpressionLanguages', function() {
     it('should use provided options', () => {
 
       // given
-      const providedOptions = DEFAULT_OPTIONS.slice(1, 3);
       const expressionLanguages = createExpressionLanguages({
         expressionLanguages: {
-          options: providedOptions
+          options: CUSTOM_OPTIONS
         }
       });
 
@@ -142,7 +150,7 @@ describe('ExpressionLanguages', function() {
       const options = expressionLanguages.getAll();
 
       // then
-      expect(options).to.deep.eql(providedOptions);
+      expect(options).to.deep.eql(CUSTOM_OPTIONS);
     });
   });
 });


### PR DESCRIPTION
Closes #675

BREAKING CHANGES:

* The only expression language selectable per default is FEEL.
  To change the list, pass respective ELs via `expressionLanguages`
  configuration.
