### PR TITLE
fix: edit button no longer always shows on scroll in decision table

### DIFF
--- a/packages/dmn-js-decision-table/src/features/simple-mode/components/SimpleModeButtonComponent.js
+++ b/packages/dmn-js-decision-table/src/features/simple-mode/components/SimpleModeButtonComponent.js
@@ -59,9 +59,10 @@ export default class SimpleModeButtonComponent extends Component {
   }
 
   hideAndShowDebounced() {
-    this.hide();
-
-    this.showDebounced();
+    if (this.state.isVisible) {
+      this.hide();
+      this.showDebounced();
+    }
   }
 
   showDebounced() {


### PR DESCRIPTION
Closes https://github.com/bpmn-io/dmn-js/issues/668

![firefox_tebMxBit0w](https://user-images.githubusercontent.com/17801113/168584788-c6570571-c0e2-4ad3-ad87-a61fb7e30015.gif)

This was a small oversight to apply the debounced hide then show even when the button was already hidden to start with. 