### PR TITLE
feat: change default black to off black

### DIFF
--- a/packages/dmn-js-drd/src/draw/DrdRenderer.js
+++ b/packages/dmn-js-drd/src/draw/DrdRenderer.js
@@ -31,6 +31,8 @@ import {
 
 var RENDERER_IDS = new Ids();
 
+var black = 'hsl(225, 10%, 15%)';
+
 /**
  * Renderer for the DRD view. The default colors are configurable.
  * When default label color is not provided, it will take the default
@@ -71,7 +73,7 @@ export default function DrdRenderer(
   var markers = {};
 
   var defaultFillColor = config && config.defaultFillColor || 'white',
-      defaultStrokeColor = config && config.defaultStrokeColor || 'black',
+      defaultStrokeColor = config && config.defaultStrokeColor || black,
       defaultLabelColor = config && config.defaultLabelColor;
 
   function marker(type, fill, stroke) {
@@ -215,7 +217,7 @@ export default function DrdRenderer(
     offset = offset || 0;
 
     attrs = computeStyle(attrs, {
-      stroke: 'black',
+      stroke: black,
       strokeWidth: 2,
       fill: 'white'
     });
@@ -265,7 +267,7 @@ export default function DrdRenderer(
 
     attrs = computeStyle(attrs, [ 'no-fill' ], {
       strokeWidth: 2,
-      stroke: 'black'
+      stroke: black
     });
 
     var path = svgCreate('path');
@@ -478,7 +480,7 @@ export default function DrdRenderer(
 
   function drawLine(p, waypoints, attrs) {
     attrs = computeStyle(attrs, [ 'no-fill' ], {
-      stroke: 'black',
+      stroke: black,
       strokeWidth: 2,
       fill: 'none'
     });

--- a/packages/dmn-js-drd/test/spec/draw/DrdRendererSpec.js
+++ b/packages/dmn-js-drd/test/spec/draw/DrdRendererSpec.js
@@ -54,8 +54,8 @@ describe('draw - DrdRenderer', function() {
 
       // then
       expect(domQuery('rect', visual).style.fill).to.equal('white');
-      expect(domQuery('rect', visual).style.stroke).to.equal('black');
-      expect(domQuery('text', visual).style.fill).to.equal('black');
+      expect(domQuery('rect', visual).style.stroke).to.equal('rgb(34, 36, 42)');
+      expect(domQuery('text', visual).style.fill).to.equal('rgb(34, 36, 42)');
     });
 
 


### PR DESCRIPTION
`#000000` changed to `hsl(225, 10%, 15%)` according to [571](https://github.com/bpmn-io/diagram-js/issues/571).

![image](https://user-images.githubusercontent.com/7633572/169476307-50d8f468-62d8-40ed-ba3a-5019c57d1017.png)

---

Related to https://github.com/bpmn-io/diagram-js/issues/571