### PR TITLE
fix(i18n): complete missing translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "distro": "run-s clean reinstall build-distro",
     "dev": "run-s build \"lerna-dev -- {@}\" -- ",
     "start": "cross-env SINGLE_START=modeler npm run dev -- dmn-js",
+    "start:translate": "cross-env SINGLE_START=translate npm run dev -- dmn-js",
     "lerna-dev": "lerna run dev --stream --scope",
     "build": "lerna run build --parallel --stream",
     "lerna-publish": "lerna publish -m \"chore(project): publish %s\"",

--- a/packages/dmn-js-decision-table/src/features/allowed-values/components/AllowedValuesEditing.js
+++ b/packages/dmn-js-decision-table/src/features/allowed-values/components/AllowedValuesEditing.js
@@ -37,7 +37,7 @@ export default class AllowedValuesEditing extends Component {
             value,
             isCheckable: false,
             isRemovable: true,
-            group: 'Predefined Values'
+            group: this._translate('Predefined Values')
           };
         }),
         inputValue: ''
@@ -126,7 +126,7 @@ export default class AllowedValuesEditing extends Component {
           value,
           isCheckable: false,
           isRemovable: true,
-          group: 'Predefined Values'
+          group: this._translate('Predefined Values')
         };
       })));
 
@@ -202,7 +202,7 @@ export default class AllowedValuesEditing extends Component {
             <ValidatedInput
               onInput={ this.onInput }
               onKeyDown={ this.onKeyDown }
-              placeholder={ '"value", "value", ...' }
+              placeholder={ this._translate('"value", "value", ...') }
               type="text"
               validate={ value => {
                 if (!parseString(value)) {

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
@@ -129,7 +129,7 @@ export default class InputCell extends Component {
               this._translate('Input Type')
           }
         >
-          { inputValues && inputValues.text || inputExpression.typeRef }
+          { inputValues && inputValues.text || this._translate(inputExpression.typeRef) }
         </div>
       </th>
     );

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditor.js
@@ -60,7 +60,7 @@ export default class InputEditor extends Component {
           </label>
 
           <ContentEditable
-            placeholder="enter expression"
+            placeholder={ this.translate('enter expression') }
             className={
               [
                 'ref-text',

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputCell.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputCell.js
@@ -120,7 +120,7 @@ export default class OutputCell extends Component {
               this._translate('Output Type')
           }
         >
-          { outputValues && outputValues.text || typeRef }
+          { outputValues && outputValues.text || this._translate(typeRef) }
         </div>
       </th>
     );

--- a/packages/dmn-js-decision-table/src/features/decision-table-properties/components/DecisionTablePropertiesComponent.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-properties/components/DecisionTablePropertiesComponent.js
@@ -9,6 +9,8 @@ export default class DecisionTablePropertiesComponent extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
+
     inject(this);
   }
 
@@ -25,7 +27,8 @@ export default class DecisionTablePropertiesComponent extends Component {
 
     return (
       <div className="decision-table-properties">
-        <div className="decision-table-name" title={ 'Decision Name: ' + name }>
+        <div className="decision-table-name" title={
+          this._translate('Decision Name: ') + name }>
           { name }
         </div>
         <div className="decision-table-header-separator" />

--- a/packages/dmn-js-decision-table/src/features/decision-table-properties/components/DecisionTablePropertiesEditorComponent.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-properties/components/DecisionTablePropertiesEditorComponent.js
@@ -89,6 +89,8 @@ class DecisionTableName extends EditableComponent {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
+
     mixin(this, SelectionAware);
   }
 
@@ -106,7 +108,7 @@ class DecisionTableName extends EditableComponent {
         className={ className }
         data-element-id={ this.props.elementId }
         data-coords={ this.props.coords }
-        title={ 'Decision Name: ' + name }
+        title={ this._translate('Decision Name: ') + name }
       >
         { this.getEditor() }
       </div>

--- a/packages/dmn-js-decision-table/src/features/hit-policy/components/HitPolicy.js
+++ b/packages/dmn-js-decision-table/src/features/hit-policy/components/HitPolicy.js
@@ -13,6 +13,8 @@ export default class HitPolicy extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
+
     inject(this);
   }
 
@@ -33,13 +35,13 @@ export default class HitPolicy extends Component {
     return (
       <div
         className="hit-policy header"
-        title={ hitPolicyEntry.explanation }
+        title={ this._translate(hitPolicyEntry.explanation) }
       >
         <label className="dms-label">
-          Hit Policy:
+          { this._translate('Hit Policy:') }
         </label>
         <span className="hit-policy-value">
-          { hitPolicyEntry.label}
+          { this._translate(hitPolicyEntry.label) }
         </span>
       </div>
     );

--- a/packages/dmn-js-decision-table/src/features/hit-policy/editor/components/EditableHitPolicy.js
+++ b/packages/dmn-js-decision-table/src/features/hit-policy/editor/components/EditableHitPolicy.js
@@ -16,6 +16,8 @@ export default class EditableHitPolicy extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
+
     inject(this);
   }
 
@@ -50,14 +52,15 @@ export default class EditableHitPolicy extends Component {
     });
 
     return (
-      <div className="hit-policy" title={ hitPolicyEntry.explanation }>
+      <div className="hit-policy" title={ this._translate(hitPolicyEntry.explanation) }>
         <label className="dms-label">
-          Hit Policy:
+          { this._translate('Hit Policy:') }
         </label>
         <InputSelect
           className="hit-policy-edit-policy-select"
           onChange={ this.onChange }
-          options={ HIT_POLICIES }
+          options={ HIT_POLICIES.map(entry =>
+            ({ ...entry, label: this._translate(entry.label) })) }
           value={ hitPolicyEntry.value }
           data-hit-policy="true"
           noInput

--- a/packages/dmn-js-decision-table/src/features/simple-boolean-edit/components/BooleanEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-boolean-edit/components/BooleanEdit.js
@@ -14,6 +14,7 @@ export default class BooleanEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -50,19 +51,19 @@ export default class BooleanEdit extends Component {
       label: '-',
       value: NONE
     }, {
-      label: 'Yes',
+      label: this._translate('Yes'),
       value: TRUE
     }, {
-      label: 'No',
+      label: this._translate('No'),
       value: FALSE
     }];
 
     return (
       <div class="simple-boolean-edit context-menu-container">
 
-        <h3 class="dms-heading">Edit Boolean</h3>
+        <h3 class="dms-heading">{this._translate('Edit Boolean')}</h3>
 
-        <h4 class="dms-heading">Set Value</h4>
+        <h4 class="dms-heading">{this._translate('Set Value')}</h4>
 
         <InputSelect
           noInput={ true }

--- a/packages/dmn-js-decision-table/src/features/simple-date-edit/components/InputDateEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-date-edit/components/InputDateEdit.js
@@ -22,6 +22,7 @@ export default class InputDateEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -146,23 +147,23 @@ export default class InputDateEdit extends Component {
     const { dates, type } = this.state;
 
     const options = [{
-      label: 'Exactly',
+      label: this._translate('Exactly'),
       value: EXACT
     }, {
-      label: 'Before',
+      label: this._translate('Before'),
       value: BEFORE
     }, {
-      label: 'After',
+      label: this._translate('After'),
       value: AFTER
     }, {
-      label: 'Between',
+      label: this._translate('Between'),
       value: BETWEEN
     }];
 
     return (
       <div class="context-menu-container simple-date-edit">
 
-        <h3 class="dms-heading">Edit date</h3>
+        <h3 class="dms-heading">{ this._translate('Edit date') }</h3>
 
         <div className="dms-fill-row">
           <InputSelect
@@ -175,8 +176,8 @@ export default class InputDateEdit extends Component {
         <h4 class="dms-heading">
           {
             type === BETWEEN
-              ? 'Edit start date'
-              : 'Set date'
+              ? this._translate('Edit start date')
+              : this._translate('Set date')
           }
         </h4>
 
@@ -184,21 +185,26 @@ export default class InputDateEdit extends Component {
           <ValidatedInput
             className="start-date-input dms-block"
             onInput={ this.onStartDateInput }
-            placeholder={ `e.g. ${ getSampleDate() }` }
-            validate={ validateISOString }
+            placeholder={ this._translate('e.g. { sample }', {
+              sample: getSampleDate()
+            }) }
+            validate={ string => validateISOString(string) &&
+              this._translate(validateISOString(string)) }
             value={ dates[0] } />
 
           <p className="dms-hint">
             <button type="button"
               className="use-today"
-              onClick={ this.onSetStartDateTodayClick }>Use today</button>.
+              onClick={ this.onSetStartDateTodayClick }>
+              { this._translate('Use today') }
+            </button>.
           </p>
         </div>
 
         {
           type === BETWEEN
             && <h4 class="dms-heading">
-              Edit end date
+              { this._translate('Edit end date') }
             </h4>
         }
 
@@ -208,15 +214,20 @@ export default class InputDateEdit extends Component {
               <ValidatedInput
                 className="end-date-input dms-block"
                 onInput={ this.onEndDateInput }
-                placeholder={ `e.g. ${ getSampleDate() }` }
-                validate={ validateISOString }
+                placeholder={ this._translate('e.g. { sample }', {
+                  sample: getSampleDate()
+                }) }
+                validate={ string => validateISOString(string) &&
+                  this._translate(validateISOString(string)) }
                 value={ dates[1] }>
               </ValidatedInput>
 
               <p className="dms-hint">
                 <button type="button"
                   className="use-today"
-                  onClick={ this.onSetEndDateTodayClick }>Use today</button>.
+                  onClick={ this.onSetEndDateTodayClick }>
+                  { this._translate('Use today') }
+                </button>.
               </p>
             </div>
         }

--- a/packages/dmn-js-decision-table/src/features/simple-date-edit/components/OutputDateEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-date-edit/components/OutputDateEdit.js
@@ -14,6 +14,7 @@ export default class OutputDateEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -65,23 +66,26 @@ export default class OutputDateEdit extends Component {
     return (
       <div class="context-menu-container simple-date-edit">
 
-        <h3 class="dms-heading">Edit date</h3>
+        <h3 class="dms-heading">{ this._translate('Edit date') }</h3>
 
-        <h4 class="dms-heading">Set date</h4>
+        <h4 class="dms-heading">{ this._translate('Set date') }</h4>
 
         <div>
           <ValidatedInput
             onInput={ this.onInput }
-            placeholder={ `e.g. ${ getSampleDate() }` }
-            validate={ validateISOString }
+            placeholder={ this._translate('e.g. { example } ', {
+              example: getSampleDate()
+            }) }
+            validate={ string => validateISOString(string) &&
+              this._translate(validateISOString(string)) }
             value={ date }
             className="dms-block">
           </ValidatedInput>
 
           <p className="dms-hint">
-            Set date <button type="button"
+            { this._translate('Set date') } <button type="button"
               className="use-today"
-              onClick={ this.onClick }>to today</button>.
+              onClick={ this.onClick }>{ this._translate('to today') }</button>.
           </p>
         </div>
 

--- a/packages/dmn-js-decision-table/src/features/simple-date-time-edit/components/InputDateTimeEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-date-time-edit/components/InputDateTimeEdit.js
@@ -22,6 +22,7 @@ export default class InputDateEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -146,23 +147,23 @@ export default class InputDateEdit extends Component {
     const { dates, type } = this.state;
 
     const options = [{
-      label: 'Exactly',
+      label: this._translate('Exactly'),
       value: EXACT
     }, {
-      label: 'Before',
+      label: this._translate('Before'),
       value: BEFORE
     }, {
-      label: 'After',
+      label: this._translate('After'),
       value: AFTER
     }, {
-      label: 'Between',
+      label: this._translate('Between'),
       value: BETWEEN
     }];
 
     return (
       <div class="context-menu-container simple-date-edit">
 
-        <h3 class="dms-heading">Edit date and time</h3>
+        <h3 class="dms-heading">{ this._translate('Edit date and time') }</h3>
 
         <div className="dms-fill-row">
           <InputSelect
@@ -175,8 +176,8 @@ export default class InputDateEdit extends Component {
         <h4 class="dms-heading">
           {
             type === BETWEEN
-              ? 'Edit start date'
-              : 'Set date'
+              ? this._translate('Edit start date')
+              : this._translate('Set date')
           }
         </h4>
 
@@ -184,21 +185,26 @@ export default class InputDateEdit extends Component {
           <ValidatedInput
             className="start-date-input dms-block"
             onInput={ this.onStartDateInput }
-            placeholder={ `e.g. ${ getSampleDate() }` }
-            validate={ validateISOString }
+            placeholder={ this._translate('e.g. { sample }', {
+              sample: getSampleDate()
+            }) }
+            validate={ string => validateISOString(string) &&
+              this._translate(validateISOString(string)) }
             value={ dates[0] } />
 
           <p className="dms-hint">
             <button type="button"
               className="use-today"
-              onClick={ this.onSetStartDateTodayClick }>Use today</button>.
+              onClick={ this.onSetStartDateTodayClick }>
+              { this._translate('Use today') }
+            </button>.
           </p>
         </div>
 
         {
           type === BETWEEN
             && <h4 class="dms-heading">
-              Edit end date
+              { this._translate('Edit end date') }
             </h4>
         }
 
@@ -208,15 +214,20 @@ export default class InputDateEdit extends Component {
               <ValidatedInput
                 className="end-date-input dms-block"
                 onInput={ this.onEndDateInput }
-                placeholder={ `e.g. ${ getSampleDate() }` }
-                validate={ validateISOString }
+                placeholder={ this._translate('e.g. { sample }', {
+                  sample: getSampleDate()
+                }) }
+                validate={ string => validateISOString(string) &&
+                  this._translate(validateISOString(string)) }
                 value={ dates[1] }>
               </ValidatedInput>
 
               <p className="dms-hint">
                 <button type="button"
                   className="use-today"
-                  onClick={ this.onSetEndDateTodayClick }>Use today</button>.
+                  onClick={ this.onSetEndDateTodayClick }>
+                  { this._translate('Use today') }
+                </button>.
               </p>
             </div>
         }

--- a/packages/dmn-js-decision-table/src/features/simple-date-time-edit/components/OutputDateTimeEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-date-time-edit/components/OutputDateTimeEdit.js
@@ -14,6 +14,7 @@ export default class OutputDateEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -65,23 +66,26 @@ export default class OutputDateEdit extends Component {
     return (
       <div class="context-menu-container simple-date-edit">
 
-        <h3 class="dms-heading">Edit date and time</h3>
+        <h3 class="dms-heading">{ this._translate('Edit date and time') }</h3>
 
-        <h4 class="dms-heading">Set date and time</h4>
+        <h4 class="dms-heading">{ this._translate('Set date and time') }</h4>
 
         <div>
           <ValidatedInput
             onInput={ this.onInput }
-            placeholder={ `e.g. ${ getSampleDate() }` }
-            validate={ validateISOString }
+            placeholder={ this._translate('e.g. { sample }', {
+              sample: getSampleDate()
+            }) }
+            validate={ string => validateISOString(string) &&
+              this._translate(validateISOString(string)) }
             value={ date }
             className="dms-block">
           </ValidatedInput>
 
           <p className="dms-hint">
-            Use <button type="button"
+            {this._translate('Use')} <button type="button"
               className="use-today"
-              onClick={ this.onClick }>today</button>.
+              onClick={ this.onClick }>{this._translate('today')}</button>.
           </p>
         </div>
 

--- a/packages/dmn-js-decision-table/src/features/simple-duration-edit/components/DurationInput.js
+++ b/packages/dmn-js-decision-table/src/features/simple-duration-edit/components/DurationInput.js
@@ -14,6 +14,7 @@ export class DurationInput extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._type = props.type;
 
     this.onInput = this.onInput.bind(this);
@@ -34,15 +35,15 @@ export class DurationInput extends Component {
 
   validate(value) {
     if (!validateDuration(this._type, value)) {
-      return ERROR_MESSAGE[this._type];
+      return this._translate(ERROR_MESSAGE[this._type]);
     }
   }
 
   _getPlaceholder() {
     if (this._type === 'yearMonthDuration') {
-      return 'e.g. P1Y2M';
+      return this._translate('e.g. { sample }', { sample: 'P1Y2M' });
     } else if (this._type === 'dayTimeDuration') {
-      return 'e.g. P1DT2H';
+      this._translate('e.g. { sample }', { sample: 'P1DT2H' });
     }
   }
 

--- a/packages/dmn-js-decision-table/src/features/simple-duration-edit/components/InputDurationEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-duration-edit/components/InputDurationEdit.js
@@ -18,6 +18,7 @@ export default class InputDurationEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -193,19 +194,19 @@ export default class InputDurationEdit extends Component {
 
   renderComparison(comparisonOperator, comparisonValue) {
     const comparisonOperatorOptions = [{
-      label: 'Equals',
+      label: this._translate('Equals'),
       value: 'equals'
     }, {
-      label: 'Less',
+      label: this._translate('Less'),
       value: 'less'
     }, {
-      label: 'Less or equals',
+      label: this._translate('Less or equals'),
       value: 'lessEquals'
     }, {
-      label: 'Greater',
+      label: this._translate('Greater'),
       value: 'greater'
     }, {
-      label: 'Greater or equals',
+      label: this._translate('Greater or equals'),
       value: 'greaterEquals'
     }];
 
@@ -236,16 +237,16 @@ export default class InputDurationEdit extends Component {
 
   renderRange(rangeStartValue, rangeEndValue, rangeStartType, rangeEndType) {
     const rangeTypeOptions = [{
-      label: 'Include',
+      label: this._translate('Include'),
       value: 'include'
     }, {
-      label: 'Exclude',
+      label: this._translate('Exclude'),
       value: 'exclude'
     }];
 
     return (
       <div className="range">
-        <h4 className="dms-heading">Start value</h4>
+        <h4 className="dms-heading">{ this._translate('Start value') }</h4>
 
         <div className="dms-fill-row dms-input-duration-edit-row">
           <InputSelect
@@ -264,7 +265,7 @@ export default class InputDurationEdit extends Component {
         </div>
 
         <h4 className="dms-heading">
-          End value
+          { this._translate('End value') }
         </h4>
 
         <div className="dms-fill-row dms-input-duration-edit-row">
@@ -298,17 +299,17 @@ export default class InputDurationEdit extends Component {
     } = this.state;
 
     const typeOptions = [{
-      label: 'Comparison',
+      label: this._translate('Comparison'),
       value: COMPARISON
     }, {
-      label: 'Range',
+      label: this._translate('Range'),
       value: RANGE
     }];
 
     return (
       <div class="context-menu-container simple-duration-edit">
 
-        <h3 class="dms-heading">Edit duration</h3>
+        <h3 class="dms-heading">{ this._translate('Edit duration') }</h3>
 
         <div className="dms-fill-row">
           <InputSelect

--- a/packages/dmn-js-decision-table/src/features/simple-duration-edit/components/OutputDurationEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-duration-edit/components/OutputDurationEdit.js
@@ -9,6 +9,7 @@ export default class OutputDurationEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -40,9 +41,9 @@ export default class OutputDurationEdit extends Component {
     return (
       <div class="context-menu-container simple-duration-edit">
 
-        <h3 class="dms-heading">Edit duration</h3>
+        <h3 class="dms-heading">{ this._translate('Edit duration') }</h3>
 
-        <h4 class="dms-heading">Set duration</h4>
+        <h4 class="dms-heading">{ this._translate('Set duration') }</h4>
 
         <DurationInput
           onInput={ this.onInput }

--- a/packages/dmn-js-decision-table/src/features/simple-mode/components/SimpleModeButtonComponent.js
+++ b/packages/dmn-js-decision-table/src/features/simple-mode/components/SimpleModeButtonComponent.js
@@ -18,6 +18,7 @@ export default class SimpleModeButtonComponent extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this.state = {
       top: 0,
       left: 0,
@@ -251,8 +252,8 @@ export default class SimpleModeButtonComponent extends Component {
           ref={ node => this.node = node }
           style={ { top, left } }
           title={ isDisabled
-            ? 'Editing not supported for set expression language'
-            : 'Edit' }><span className="dmn-icon-edit"></span></div>
+            ? this._translate('Editing not supported for set expression language')
+            : this._translate('Edit') }><span className="dmn-icon-edit"></span></div>
         : null
     );
   }

--- a/packages/dmn-js-decision-table/src/features/simple-number-edit/components/InputNumberEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-number-edit/components/InputNumberEdit.js
@@ -17,6 +17,7 @@ export default class InputNumberEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -193,26 +194,26 @@ export default class InputNumberEdit extends Component {
 
   renderComparison(comparisonOperator, comparisonValue) {
     const comparisonOperatorOptions = [{
-      label: 'Equals',
+      label: this._translate('Equals'),
       value: 'equals'
     }, {
-      label: 'Less',
+      label: this._translate('Less'),
       value: 'less'
     }, {
-      label: 'Less or equals',
+      label: this._translate('Less or equals'),
       value: 'lessEquals'
     }, {
-      label: 'Greater',
+      label: this._translate('Greater'),
       value: 'greater'
     }, {
-      label: 'Greater or equals',
+      label: this._translate('Greater or equals'),
       value: 'greaterEquals'
     }];
 
     return (
       <div className="comparison">
 
-        <h4 className="dms-heading">Value</h4>
+        <h4 className="dms-heading">{ this._translate('Value') }</h4>
 
         <div className="dms-fill-row">
           <InputSelect
@@ -236,16 +237,16 @@ export default class InputNumberEdit extends Component {
 
   renderRange(rangeStartValue, rangeEndValue, rangeStartType, rangeEndType) {
     const rangeTypeOptions = [{
-      label: 'Include',
+      label: this._translate('Include'),
       value: 'include'
     }, {
-      label: 'Exclude',
+      label: this._translate('Exclude'),
       value: 'exclude'
     }];
 
     return (
       <div className="range">
-        <h4 className="dms-heading">Start Value</h4>
+        <h4 className="dms-heading">{ this._translate('Start value') }</h4>
 
         <div className="dms-fill-row">
           <InputSelect
@@ -264,7 +265,7 @@ export default class InputNumberEdit extends Component {
         </div>
 
         <h4 className="dms-heading">
-          End Value
+          { this._translate('End value') }
         </h4>
 
         <div className="dms-fill-row">
@@ -299,17 +300,17 @@ export default class InputNumberEdit extends Component {
     } = this.state;
 
     const typeOptions = [{
-      label: 'Comparison',
+      label: this._translate('Comparison'),
       value: COMPARISON
     }, {
-      label: 'Range',
+      label: this._translate('Range'),
       value: RANGE
     }];
 
     return (
       <div class="context-menu-container simple-number-edit">
 
-        <h3 class="dms-heading">Edit Number</h3>
+        <h3 class="dms-heading">{ this._translate('Edit Number') }</h3>
 
         <div className="dms-fill-row">
           <InputSelect

--- a/packages/dmn-js-decision-table/src/features/simple-number-edit/components/OutputNumberEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-number-edit/components/OutputNumberEdit.js
@@ -10,6 +10,7 @@ export default class OutputNumberEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -54,9 +55,9 @@ export default class OutputNumberEdit extends Component {
     return (
       <div class="context-menu-container simple-number-edit">
 
-        <h3 class="dms-heading">Edit Number</h3>
+        <h3 class="dms-heading">{ this._translate('Edit Number') }</h3>
 
-        <h4 class="dms-heading">Set Value</h4>
+        <h4 class="dms-heading">{ this._translate('Set Value') }</h4>
 
         <Input
           onInput={ this.onInput }

--- a/packages/dmn-js-decision-table/src/features/simple-string-edit/components/SimpleStringEditContextMenuComponent.js
+++ b/packages/dmn-js-decision-table/src/features/simple-string-edit/components/SimpleStringEditContextMenuComponent.js
@@ -51,7 +51,9 @@ export default class SimpleStringEditContextMenuComponent extends Component {
         value,
         isChecked: includes(parsedString.values, value),
         isRemovable: false,
-        group: isInputClause ? INPUT_VALUES_LABEL : OUTPUT_VALUES_LABEL
+        group: isInputClause ?
+          this._translate(INPUT_VALUES_LABEL) :
+          this._translate(OUTPUT_VALUES_LABEL)
       };
     });
 
@@ -61,7 +63,7 @@ export default class SimpleStringEditContextMenuComponent extends Component {
           value,
           isChecked: true,
           isRemovable: true,
-          group: INPUT_ENTRY_VALUES_LABEL
+          group: this._translate(INPUT_ENTRY_VALUES_LABEL)
         };
       }));
     }
@@ -254,7 +256,7 @@ export default class SimpleStringEditContextMenuComponent extends Component {
         value,
         isChecked: true,
         isRemovable: true,
-        group: 'Custom Values'
+        group: this._translate('Custom Values')
       };
     }));
 
@@ -270,10 +272,10 @@ export default class SimpleStringEditContextMenuComponent extends Component {
     const { inputValue, isOutputValueInputChecked, items, unaryTestsType } = this.state;
 
     const options = [{
-      label: 'Match one',
+      label: this._translate('Match one'),
       value: DISJUNCTION
     }, {
-      label: 'Match none',
+      label: this._translate('Match none'),
       value: NEGATION
     }];
 
@@ -333,7 +335,9 @@ export default class SimpleStringEditContextMenuComponent extends Component {
             className="dms-block"
             onKeyDown={ this.onKeyDown }
             onInput={ this.onInput }
-            placeholder={ isInputClause ? '"value", "value", ...' : '"value"' }
+            placeholder={ isInputClause ?
+              this._translate('"value", "value", ...') :
+              this._translate('"value"') }
             type="text"
             validate={ value => {
               if (!parseString(value)) {

--- a/packages/dmn-js-decision-table/src/features/simple-time-edit/components/InputTimeEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-time-edit/components/InputTimeEdit.js
@@ -10,6 +10,7 @@ import {
   validateISOString,
   parseString
 } from '../Utils';
+import { getSampleDate } from '../../simple-date-edit/Utils';
 
 const EXACT = 'exact',
       BEFORE = 'before',
@@ -22,6 +23,7 @@ export default class InputTimeEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -146,23 +148,23 @@ export default class InputTimeEdit extends Component {
     const { times, type } = this.state;
 
     const options = [{
-      label: 'Exactly',
+      label: this._translate('Exactly'),
       value: EXACT
     }, {
-      label: 'Before',
+      label: this._translate('Before'),
       value: BEFORE
     }, {
-      label: 'After',
+      label: this._translate('After'),
       value: AFTER
     }, {
-      label: 'Between',
+      label: this._translate('Between'),
       value: BETWEEN
     }];
 
     return (
       <div class="context-menu-container simple-time-edit">
 
-        <h3 class="dms-heading">Edit time</h3>
+        <h3 class="dms-heading">{ this._translate('Edit time') }</h3>
 
         <div className="dms-fill-row">
           <InputSelect
@@ -175,8 +177,8 @@ export default class InputTimeEdit extends Component {
         <h4 class="dms-heading">
           {
             type === BETWEEN
-              ? 'Edit start time'
-              : 'Set time'
+              ? this._translate('Edit start time')
+              : this._translate('Set time')
           }
         </h4>
 
@@ -184,21 +186,26 @@ export default class InputTimeEdit extends Component {
           <ValidatedInput
             className="start-time-input dms-block"
             onInput={ this.onStartTimeInput }
-            placeholder={ `e.g. ${ getSampleTime() }` }
-            validate={ validateISOString }
+            placeholder={ this._translate('e.g. { example } ', {
+              example: getSampleDate()
+            }) }
+            validate={ string => validateISOString(string) &&
+              this._translate(validateISOString(string)) }
             value={ times[0] } />
 
           <p className="dms-hint">
             <button type="button"
               className="use-now"
-              onClick={ this.onSetStartTimeNowClick }>Use now</button>.
+              onClick={ this.onSetStartTimeNowClick }>
+              { this._translate('Use now') }
+            </button>.
           </p>
         </div>
 
         {
           type === BETWEEN
             && <h4 class="dms-heading">
-              Edit end time
+              {this._translate('Edit end time')}
             </h4>
         }
 
@@ -208,15 +215,20 @@ export default class InputTimeEdit extends Component {
               <ValidatedInput
                 className="end-time-input dms-block"
                 onInput={ this.onEndTimeInput }
-                placeholder={ `e.g. ${ getSampleTime() }` }
-                validate={ validateISOString }
+                placeholder={ this._translate('e.g. { example } ', {
+                  example: getSampleDate()
+                }) }
+                validate={ string => validateISOString(string) &&
+                  this._translate(validateISOString(string)) }
                 value={ times[1] }>
               </ValidatedInput>
 
               <p className="dms-hint">
                 <button type="button"
                   className="use-now"
-                  onClick={ this.onSetEndTimeNowClick }>Use now</button>.
+                  onClick={ this.onSetEndTimeNowClick }>
+                  { this._translate('Use now') }
+                </button>.
               </p>
             </div>
         }

--- a/packages/dmn-js-decision-table/src/features/simple-time-edit/components/OutputTimeEdit.js
+++ b/packages/dmn-js-decision-table/src/features/simple-time-edit/components/OutputTimeEdit.js
@@ -7,6 +7,7 @@ import {
   validateISOString,
   parseString
 } from '../Utils';
+import { getSampleDate } from '../../simple-date-edit/Utils';
 
 
 export default class OutputTimeEdit extends Component {
@@ -14,6 +15,7 @@ export default class OutputTimeEdit extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._modeling = context.injector.get('modeling');
 
     const { element } = this.props.context;
@@ -65,23 +67,26 @@ export default class OutputTimeEdit extends Component {
     return (
       <div class="context-menu-container simple-time-edit">
 
-        <h3 class="dms-heading">Edit Date</h3>
+        <h3 class="dms-heading">{ this._translate('Edit Date') }</h3>
 
-        <h4 class="dms-heading">Set Date</h4>
+        <h4 class="dms-heading">{ this._translate('Set Date') }</h4>
 
         <div>
           <ValidatedInput
             onInput={ this.onInput }
-            placeholder={ `e.g. ${ getSampleTime() }` }
-            validate={ validateISOString }
+            placeholder={ this._translate('e.g. { example } ', {
+              example: getSampleDate()
+            }) }
+            validate={ string => validateISOString(string) &&
+              this._translate(validateISOString(string)) }
             value={ date }
             className="dms-block">
           </ValidatedInput>
 
           <p className="dms-hint">
-            Set date <button type="button"
+            { this._translate('Set date') } <button type="button"
               className="use-now"
-              onClick={ this.onClick }>to now</button>.
+              onClick={ this.onClick }>{ this._translate('to now') }</button>.
           </p>
         </div>
 

--- a/packages/dmn-js-decision-table/src/features/type-ref/components/TypeRefCellContextMenu.js
+++ b/packages/dmn-js-decision-table/src/features/type-ref/components/TypeRefCellContextMenu.js
@@ -54,7 +54,7 @@ export default class TypeRefCellContextMenu extends Component {
 
     const typeRefOptions = this._dataTypes.getAll().map(t => {
       return {
-        label: t,
+        label: this._translate(t),
         value: t
       };
     });

--- a/packages/dmn-js-decision-table/src/features/view-drd/components/ViewDrdComponent.js
+++ b/packages/dmn-js-decision-table/src/features/view-drd/components/ViewDrdComponent.js
@@ -8,6 +8,7 @@ export default class ViewDrdComponent extends Component {
 
     const { injector } = context;
 
+    this._translate = injector.get('translate');
     this._eventBus = injector.get('eventBus');
   }
 
@@ -22,7 +23,7 @@ export default class ViewDrdComponent extends Component {
         ref={ node => this.node = node }>
         <button
           onClick={ this.onClick }
-          className="view-drd-button">View DRD</button>
+          className="view-drd-button">{ this._translate('View DRD') }</button>
       </div>
     );
   }

--- a/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesEdit.js
+++ b/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesEdit.js
@@ -20,11 +20,12 @@ import {
 
 
 export default function DefinitionIdEdit(
-    eventBus, modeling, canvas, definitionPropertiesView) {
+    eventBus, modeling, canvas, definitionPropertiesView, translate) {
   this._eventBus = eventBus;
   this._modeling = modeling;
   this._canvas = canvas;
   this._definitionPropertiesView = definitionPropertiesView;
+  this._translate = translate;
 
   eventBus.on('definitionIdView.create', function(event) {
     this._container = event.html;
@@ -40,7 +41,8 @@ DefinitionIdEdit.$inject = [
   'eventBus',
   'modeling',
   'canvas',
-  'definitionPropertiesView'
+  'definitionPropertiesView',
+  'translate'
 ];
 
 
@@ -92,7 +94,7 @@ DefinitionIdEdit.prototype._setup = function(node, type) {
 DefinitionIdEdit.prototype._addErrorMessage = function(errorMessage) {
   const errorHTML =
     '<span class="dmn-definitions-error-message">' +
-    errorMessage +
+    this._translate(errorMessage) +
     '</span>';
 
   var idElement = domQuery('.dmn-definitions-id', this._container);

--- a/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesView.js
+++ b/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesView.js
@@ -5,9 +5,10 @@ import {
 } from 'min-dom';
 
 
-export default function DefinitionPropertiesView(eventBus, canvas) {
+export default function DefinitionPropertiesView(eventBus, canvas, translate) {
   this._eventBus = eventBus;
   this._canvas = canvas;
+  this._translate = translate;
 
   eventBus.on('diagram.init', function() {
     this._init();
@@ -18,9 +19,23 @@ export default function DefinitionPropertiesView(eventBus, canvas) {
       this.update();
     }
   }, this);
+
+  /* markup definition */
+
+  this.HTML_MARKUP =
+    '<div class="dmn-definitions">' +
+    '<div class="dmn-definitions-name" title="' +
+      this._translate('Definition Name') +
+    '" spellcheck="false">' +
+    '</div>' +
+    '<div class="dmn-definitions-id" title="' +
+      this._translate('Definition ID') +
+    '" spellcheck="false">' +
+    '</div>' +
+    '</div>';
 }
 
-DefinitionPropertiesView.$inject = [ 'eventBus', 'canvas' ];
+DefinitionPropertiesView.$inject = [ 'eventBus', 'canvas', 'translate' ];
 
 /**
  * Initialize
@@ -30,7 +45,7 @@ DefinitionPropertiesView.prototype._init = function() {
       eventBus = this._eventBus;
 
   var parent = canvas.getContainer(),
-      container = this._container = domify(DefinitionPropertiesView.HTML_MARKUP);
+      container = this._container = domify(this.HTML_MARKUP);
 
   parent.appendChild(container);
 
@@ -58,12 +73,3 @@ DefinitionPropertiesView.prototype.update = function() {
 };
 
 
-/* markup definition */
-
-DefinitionPropertiesView.HTML_MARKUP =
-  '<div class="dmn-definitions">' +
-    '<div class="dmn-definitions-name" title="Definition Name" spellcheck="false">' +
-    '</div>' +
-    '<div class="dmn-definitions-id" title="Definition ID" spellcheck="false">' +
-    '</div>' +
-  '</div>';

--- a/packages/dmn-js-drd/src/features/definition-properties/viewer.js
+++ b/packages/dmn-js-drd/src/features/definition-properties/viewer.js
@@ -1,7 +1,9 @@
 import DefinitionPropertiesView from './DefinitionPropertiesView';
 import PaletteAdapter from './PaletteAdapter';
+import DiagramTranslate from 'diagram-js/lib/i18n/translate';
 
 export default {
+  __depends__: [ DiagramTranslate ],
   __init__: [
     'definitionPropertiesView',
     'definitionPropertiesPaletteAdapter'

--- a/packages/dmn-js-literal-expression/src/Viewer.js
+++ b/packages/dmn-js-literal-expression/src/Viewer.js
@@ -9,6 +9,8 @@ import {
   remove as domRemove
 } from 'min-dom';
 
+import TranslateModule from 'diagram-js/lib/i18n/translate';
+
 import CoreModule from './core';
 import DecisionPropertiesModule from './features/decision-properties';
 import LiteralExpressionPropertiesModule from './features/literal-expression-properties';
@@ -216,6 +218,7 @@ export default class Viewer extends BaseViewer {
   static _getModules() {
     return [
       CoreModule,
+      TranslateModule,
       DecisionPropertiesModule,
       LiteralExpressionPropertiesModule,
       PoweredByModule,

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
@@ -5,6 +5,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._viewer = context.injector.get('viewer');
   }
 
@@ -18,19 +19,19 @@ export default class LiteralExpressionPropertiesComponent extends Component {
       <div className="literal-expression-properties">
         <table>
           <tr>
-            <td>Variable Name:</td>
+            <td>{ this._translate('Variable Name:') }</td>
             <td>
               <span>{ variable.name || '-' }</span>
             </td>
           </tr>
           <tr>
-            <td>Variable Type:</td>
+            <td>{ this._translate('Variable Type:') }</td>
             <td>
-              <span>{ variable.typeRef || '-' }</span>
+              <span>{ this._translate(variable.typeRef) || '-' }</span>
             </td>
           </tr>
           <tr>
-            <td>Expression Language:</td>
+            <td>{ this._translate('Expression Language:') }</td>
             <td>
               <span>{ literalExpression.expressionLanguage || '-' }</span>
             </td>

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
@@ -8,6 +8,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._viewer = context.injector.get('viewer');
     this._modeling = context.injector.get('modeling');
     this._dataTypes = context.injector.get('dataTypes');
@@ -52,7 +53,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
 
     const typeRefOptions = this._dataTypes.getAll().map(t => {
       return {
-        label: t,
+        label: this._translate(t),
         value: t
       };
     });
@@ -61,7 +62,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
       <div className="literal-expression-properties">
         <table>
           <tr>
-            <td>Variable Name:</td>
+            <td>{ this._translate('Variable Name:') }</td>
             <td>
               <Input
                 className="variable-name-input"
@@ -71,7 +72,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
             </td>
           </tr>
           <tr>
-            <td>Variable Type:</td>
+            <td>{ this._translate('Variable Type:') }</td>
             <td>
               <div className="dms-fill-row">
                 <InputSelect
@@ -93,6 +94,7 @@ class ExpressionLanguage extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this._translate = context.injector.get('translate');
     this._viewer = context.injector.get('viewer');
     this._modeling = context.injector.get('modeling');
     this._expressionLanguages = context.injector.get('expressionLanguages');
@@ -144,7 +146,7 @@ class ExpressionLanguage extends Component {
 
     return (
       <tr>
-        <td>Expression Language:</td>
+        <td>{ this._translate('Expression Language:') }</td>
         <td>
           <div className="dms-fill-row">
             <InputSelect

--- a/packages/dmn-js-literal-expression/src/features/view-drd/components/ViewDrdComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/view-drd/components/ViewDrdComponent.js
@@ -8,6 +8,7 @@ export default class ViewDrdComponent extends Component {
 
     const { injector } = context;
 
+    this._translate = injector.get('translate');
     this._eventBus = injector.get('eventBus');
   }
 
@@ -22,9 +23,11 @@ export default class ViewDrdComponent extends Component {
         ref={ node => this.node = node }>
         <button
           onClick={ this.onClick }
-          className="view-drd-button">View DRD</button>
+          className="view-drd-button">{ this._translate('View DRD') }</button>
       </div>
     );
   }
 
 }
+
+ViewDrdComponent.$inject = [ 'translate' ];

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
@@ -22,6 +22,7 @@ import LiteralExpressionPropertiesEditorModule
 
 import CoreModule from 'src/core';
 import ModelingModule from 'src/features/modeling';
+import TranslateModule from 'diagram-js/lib/i18n/translate';
 
 
 const CUSTOM_EXPRESSION_LANGUAGES = [{
@@ -49,6 +50,7 @@ describe('literal expression properties editor', function() {
 
   const testModules = [
     CoreModule,
+    TranslateModule,
     LiteralExpressionPropertiesEditorModule,
     ModelingModule,
     ExpressionLanguagesModule,

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionPropertiesSpec.js
@@ -9,6 +9,7 @@ import literalExpressionXML from '../../literal-expression.dmn';
 import CoreModule from 'src/core';
 import LiteralExpressionPropertiesModule
   from 'src/features/literal-expression-properties';
+import TranslateModule from 'diagram-js/lib/i18n/translate';
 
 
 describe('literal expression properties', function() {
@@ -16,6 +17,7 @@ describe('literal expression properties', function() {
   beforeEach(bootstrapViewer(literalExpressionXML, {
     modules: [
       CoreModule,
+      TranslateModule,
       LiteralExpressionPropertiesModule
     ]
   }));

--- a/packages/dmn-js-shared/test/util/TranslateUtil.js
+++ b/packages/dmn-js-shared/test/util/TranslateUtil.js
@@ -1,0 +1,15 @@
+const customTranslate = (template, replacements) => {
+  replacements = replacements || {};
+
+  // Translate
+  template = `tr(${template})`;
+
+  // Replace
+  return template.replace(/{([^}]+)}/g, function(_, key) {
+    return replacements[key] && `tr(${replacements[key]})` || '{' + key + '}';
+  });
+};
+
+export const translateModule = {
+  translate: ['value', customTranslate],
+};

--- a/packages/dmn-js/test/spec/TabbingSpec.js
+++ b/packages/dmn-js/test/spec/TabbingSpec.js
@@ -9,6 +9,7 @@ import {
 
 
 import { insertCSS } from 'test/helper';
+import { translateModule } from 'dmn-js-shared/test/util/TranslateUtil';
 
 insertCSS('diagram-js.css', require('diagram-js/assets/diagram-js.css'));
 
@@ -83,6 +84,8 @@ insertCSS('tabs.css', `
   }
 `);
 
+const testTranslate = window.__env__ && window.__env__.SINGLE_START === 'translate';
+
 const CLASS_NAMES = {
   drd: 'dmn-icon-lasso-tool',
   decisionTable: 'dmn-icon-decision-table',
@@ -113,6 +116,18 @@ describe('tabs', function() {
     var $tabs = domQuery('.editor-tabs', $parent);
 
 
+    const translateModules = {
+      drd: {
+        additionalModules: [translateModule]
+      },
+      decisionTable: {
+        additionalModules: [translateModule]
+      },
+      literalExpression: {
+        additionalModules: [translateModule]
+      },
+    };
+
     var editor = new Modeler({
       container: $container,
       height: 500,
@@ -121,7 +136,8 @@ describe('tabs', function() {
         keyboard: {
           bindTo: document
         }
-      }
+      },
+      ...(testTranslate && translateModules)
     });
 
     domDelegate.bind($tabs, '.tab', 'click', function(e) {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

Hi there👋, I'm currently working on a project that utilizes dmn-js to build an online DMN modeler. The code of dmn-js is organized in a clear and concise manner. Thanks for your fantastic works. 

However, the project that I'm working on is oriented towards Chinese users, and I found the full coverage of i18n for dmn-js is still not implemented. Thus I have written this pr to address the problem (Closes #88).

The newly added translations are listed at the bottom of this pr.

Except for code modification to add translations, I have also modified `packages/dmn-js/test/spec/TabbingSpec.js` to enable check for missing translations. You can use the following command to check:

```shell
TEST_BROWSERS=Chrome;SINGLE_START=translation npm run dev -- dmn-js
```

Every text is shown as `tr(xxx)` if it's translatable:

![image](https://user-images.githubusercontent.com/32592585/184500875-954021da-31e6-4986-9ce9-816dcc7aeeac.png)


# ADDED TRANSLATIONS

## DRD

- Definition Properties
  - Title for Decision Name
  - Title for Decision ID
  - DecisionIdEdit Error Message

## Decision Table

- Decision Table Properties
  - Title for Decision Name
- Hit Policy
  - Label
  - Value
  - Explanation
  - Options
- Table Head
  - Input Cell
    - Type Ref
  - Input Cell Context Menu
    - Placeholder for Enter Expression
  - Output Cell
    - Type Ref
  - Allowed Values Editing
    - Placeholder for Predefined Values
    - Label for Nonempty Predefined Values
  - Type Ref Cell Context Menu
    - Options for Type Ref
- Simple Mode Button
  - Title
- Simple Boolean Edit
  - Heading
  - Options
  - Placeholder
  - Error Message
- Simple Date Edit
  - Heading
  - Options
  - Validation
- Simple Date Time Edit
  - Heading
  - Options
  - Validation
- Simple Duration Edit
  - Heading
  - Options
  - Validation
- Simple Number Edit
  - Heading
  - Options
  - Validation
- Simple String Edit
  - Input Options (match one / match none)
  - Label for Predefined Values
  - Label for Custom Values
  - Placeholder for Adding Values or Setting Value
- Simple Time Edit
  - Heading
  - Options
  - Validation
- View Drd Button
  - Button Text

## Literal Expression

- Literal Expression Properties
  - Label for Variable Name
  - Label for Variable Type
  - Options for Variable Type Ref
  - Label for Expression Language
- View Drd Button
  - Button Text
