### PR TITLE
feat: transpile to ES2018

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env", {
+        "modules": false,
+        "targets":  "supports async-functions and supports rest-parameters"
+      }
+    ]
+  ]
+}

--- a/packages/dmn-js-decision-table/.babelrc
+++ b/packages/dmn-js-decision-table/.babelrc
@@ -1,11 +1,7 @@
 {
+  "extends": "../../babel.config.json",
   "plugins": [
     "inferno",
-    "@babel/plugin-transform-object-assign",
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
-  ],
-  "presets": [
-    [ "@babel/preset-env", { "modules": false } ]
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/packages/dmn-js-drd/.babelrc
+++ b/packages/dmn-js-drd/.babelrc
@@ -1,8 +1,3 @@
 {
-  "plugins": [
-    "@babel/plugin-proposal-object-rest-spread"
-  ],
-  "presets": [
-    [ "@babel/preset-env", { "modules": false } ]
-  ]
+  "extends": "../../babel.config.json"
 }

--- a/packages/dmn-js-literal-expression/.babelrc
+++ b/packages/dmn-js-literal-expression/.babelrc
@@ -1,11 +1,7 @@
 {
+  "extends": "../../babel.config.json",
   "plugins": [
     "inferno",
-    "@babel/plugin-transform-object-assign",
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
-  ],
-  "presets": [
-    [ "@babel/preset-env", { "modules": false } ]
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/packages/dmn-js-shared/.babelrc
+++ b/packages/dmn-js-shared/.babelrc
@@ -1,11 +1,7 @@
 {
+  "extends": "../../babel.config.json",
   "plugins": [
     "inferno",
-    "@babel/plugin-transform-object-assign",
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
-  ],
-  "presets": [
-    [ "@babel/preset-env", { "modules": false } ]
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/packages/dmn-js/.babelrc
+++ b/packages/dmn-js/.babelrc
@@ -1,5 +1,3 @@
 {
-  "presets": [
-    [ "@babel/preset-env", { "modules": false } ]
-  ]
+  "extends": "../../babel.config.json"
 }

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+## 13.0.0
+
+* `FEAT`: use ES2018 syntax ([#717](https://github.com/bpmn-io/bpmn-js/pull/717))
+
+### Breaking Changes
+
+* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).
+
 ## 12.3.0
 
 * `FEAT`: add missing translations ([#710](https://github.com/bpmn-io/dmn-js/pull/710), [#88](https://github.com/bpmn-io/dmn-js/issues/88))


### PR DESCRIPTION
# Breaking Changes

* Migrated to ES2018 syntax. [Read the blog post with details and a migration guide](https://bpmn.io/blog/posts/2022-core-libraries-migrated-to-es2018.html).

---

Requires https://github.com/bpmn-io/bpmn.io/pull/147