### PR TITLE
feat: break long expression names

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
@@ -323,7 +323,6 @@
 .dmn-decision-table-container thead .output-name {
   margin: 16px 6px;
   font-size: 16px;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -331,7 +330,9 @@
 .dmn-decision-table-container .input-cell .input-label,
 .dmn-decision-table-container .input-cell .output-label,
 .dmn-decision-table-container .input-cell .output-name {
-  display: block;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 .dmn-decision-table-container thead .input-expression:empty::before {

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/components/DecisionTableHead.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/components/DecisionTableHead.js
@@ -143,13 +143,15 @@ function DefaultInputHeaderCell(props, context) {
 
       {
         label ? (
-          <div className="input-label" title={ translate('Input Label') }>
+          <div
+            className="input-label"
+            title={ translate('Input Label: ') + label }>
             { label }
           </div>
         ) : (
           <div
             className="input-expression"
-            title={ translate('Input Expression') }>
+            title={ translate('Input Expression: ') + inputExpression.text }>
             { inputExpression.text }
           </div>
         )

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputCell.js
@@ -110,13 +110,15 @@ export default class InputCell extends Component {
 
         {
           label ? (
-            <div className="input-label" title={ this._translate('Input Label') }>
+            <div
+              className="input-label"
+              title={ this._translate('Input Label: ') + label }>
               { label }
             </div>
           ) : (
             <div
               className="input-expression"
-              title={ this._translate('Input Expression') }>
+              title={ this._translate('Input Expression: ') + inputExpression.text }>
               { inputExpression.text }
             </div>
           )

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputCell.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputCell.js
@@ -103,11 +103,15 @@ export default class OutputCell extends Component {
 
         {
           label ? (
-            <div className="output-label" title={ this._translate('Output Label') }>
+            <div
+              className="output-label"
+              title={ this._translate('Output Label: ') + label }>
               { label }
             </div>
           ) : (
-            <div className="output-name" title={ this._translate('Output Name') }>
+            <div
+              className="output-name"
+              title={ this._translate('Output Name: ') + name }>
               { name }
             </div>
           )


### PR DESCRIPTION
![Recording 2023-01-31 at 14 20 51](https://user-images.githubusercontent.com/21984219/215771824-e9694501-5584-42ec-89ae-426e96cbaa7a.gif)

- show the label as `title` so hover always shows complete label
- break label up to 3 lines
- Use ellipses afterwards to prevent super long labels or expressions of taking up the whole screen

Note: I used `-webkit-line-clamp` for multi-line ellipsis. This is supported in all major browsers (except IE, cf. https://caniuse.com/css-line-clamp)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
