### PR TITLE
fix(literal-expression): avoid translate to fail with undefined typeRef

### DIFF
--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
@@ -27,7 +27,8 @@ export default class LiteralExpressionPropertiesComponent extends Component {
           <tr>
             <td>{ this._translate('Variable Type:') }</td>
             <td>
-              <span>{ this._translate(variable.typeRef) || '-' }</span>
+              <span>{ this._translate(variable.typeRef || '') || '-' }</span>
+
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Closes https://github.com/camunda/web-modeler/issues/4252

There are situations when the `typeRef` related to a Literal Expression is just undefined. In these situations an error is thrown:
```
react_devtools_backend.js:2655 unhandled error in event listener TypeError: Cannot read properties of undefined (reading 'replace')
    at LiteralExpressionPropertiesComponent.translate [as _translate] (translate.js?e4f0:27:1)
    at LiteralExpressionPropertiesComponent.render (LiteralExpressionPropertiesComponent.js?7b38:13:415)
```
![image](https://user-images.githubusercontent.com/22591802/229831970-38ae4c5e-a719-4d90-8606-8d48928f0de1.png)

With the proposed change, the `translate` function would return `undefined` (instead of blocking with an error), so the hyphen will be shown for this particular "Variable Type":
![image](https://user-images.githubusercontent.com/22591802/229832384-46db75db-6fa6-47df-abaa-cfe546d656d9.png)
