### PR TITLE
fix: display FEEL autocomplete suggestions in correct position

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table.css
@@ -59,7 +59,6 @@
 .dmn-decision-table-container .tjs-container {
   display: flex;
   flex-direction: column;
-  position: relative;
   width: min-content;
   max-width: 100%;
   height: 100%;
@@ -430,13 +429,9 @@
 /* end view drd */
 
 /* powered by */
-.dmn-js-parent {
-  /* required to apply position: fixed correctly */
-  transform: translate(0);
-}
 
 .dmn-decision-table-container .powered-by {
-  position: fixed;
+  position: absolute;
   bottom: 10px;
   right: 10px;
   z-index: 9999;
@@ -448,7 +443,7 @@
 }
 
 .dmn-decision-table-container .powered-by-overlay {
-  position: fixed;
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+## 14.3.1
+
+* `FIX`: display FEEL autocomplete suggestions in correct position
+
 ## 14.3.0
 
 * `FEAT`: change table cell font to `monospace` ([`4643870`](https://github.com/bpmn-io/dmn-js/commit/46438706f75c6d99f9d92140685a7fec31101ba5))


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/pull/3881#issuecomment-1733249226

Learning: `transform`s break computed positions in autocomplete, so we should try to avoid it if possible.