### PR TITLE
fix: make FEEL editor in literal expression save value

### DIFF
--- a/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/textarea/components/TextareaEditorComponent.js
@@ -69,7 +69,7 @@ class FeelEditor extends Component {
     return <LiteralExpression
       className={ this.props.className }
       value={ this.props.value }
-      onChange={ this.props.onChange }
+      onInput={ this.props.onChange }
     />;
   }
 }

--- a/packages/dmn-js-literal-expression/test/helper/index.js
+++ b/packages/dmn-js-literal-expression/test/helper/index.js
@@ -156,7 +156,7 @@ export function inject(fn) {
       throw new Error('DecisionTable instance not found');
     }
 
-    view.invoke(fn);
+    return view.invoke(fn);
   };
 }
 

--- a/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaEditorSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/textarea/TextareaEditorSpec.js
@@ -50,10 +50,10 @@ describe('textarea editor', function() {
     // given
     const editor = queryEditor('.textarea', testContainer);
 
-    editor.focus();
+    await act(() => editor.focus());
 
     // when
-    await changeInput(editor, 'foo');
+    await changeInput(document.activeElement, 'foo');
 
     // then
     expect(viewer.getDecision().decisionLogic.text).to.equal('foo');
@@ -84,8 +84,11 @@ describe('textarea editor', function() {
  * @param {string} value
  */
 function changeInput(input, value) {
-  input.textContent = value;
+  return act(() => input.textContent = value);
+}
 
+function act(fn) {
+  fn();
   return new Promise(resolve => {
     requestAnimationFrame(() => {
       resolve();


### PR DESCRIPTION
This was caused by an API mismatch. `ContentEditable` and `LiteralExpression` accept `onInput` while `EditableComponent` expects `onChange`.

Closes #786 

