### PR TITLE
fix: add missing translations

### DIFF
--- a/packages/dmn-js-decision-table/src/features/add-rule/components/AddRuleFootComponent.js
+++ b/packages/dmn-js-decision-table/src/features/add-rule/components/AddRuleFootComponent.js
@@ -32,7 +32,10 @@ export default class AddRuleFootComponent extends Component {
 
     const cells = [
       <td className="add-rule-add">
-        <span className="dmn-icon-plus action-icon" title="Add Rule"></span>
+        <span
+          className="dmn-icon-plus action-icon"
+          title={ this.translate('Add Rule') }>
+        </span>
       </td>
     ];
 
@@ -77,4 +80,4 @@ export default class AddRuleFootComponent extends Component {
   }
 }
 
-AddRuleFootComponent.$inject = [ 'sheet' ];
+AddRuleFootComponent.$inject = [ 'sheet', 'translate' ];

--- a/packages/dmn-js-decision-table/src/features/drag-and-drop/DragAndDrop.js
+++ b/packages/dmn-js-decision-table/src/features/drag-and-drop/DragAndDrop.js
@@ -21,13 +21,14 @@ export default class DragAndDrop {
 
   constructor(
       components, elementRegistry, eventBus,
-      dragAndDrop, renderer, rules, sheet) {
+      dragAndDrop, renderer, rules, sheet, translate) {
 
     this._elementRegistry = elementRegistry;
     this._dragAndDrop = dragAndDrop;
     this._renderer = renderer;
     this._rules = rules;
     this._sheet = sheet;
+    this._translate = translate;
 
     // provide drag handle for drag and drop
     components.onGetComponent('cell-inner', ({ cellType, col, row }) => {
@@ -36,7 +37,7 @@ export default class DragAndDrop {
           draggable="true"
           onDragStart={ e => this.startDrag(row, e) }
           className="dmn-icon-drag vertical"
-          title="Move rule">&nbsp;</span>;
+          title={ this._translate('Move rule') }>&nbsp;</span>;
       } else if (cellType === 'input-cell' || cellType === 'output-cell') {
 
         let title = `Move ${isInput(col) ? 'Input' : 'Output' }`;
@@ -309,7 +310,8 @@ DragAndDrop.$inject = [
   'dragAndDrop',
   'renderer',
   'rules',
-  'sheet'
+  'sheet',
+  'translate'
 ];
 
 // helpers //////////

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
@@ -67,7 +67,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
               <Input
                 className="variable-name-input"
                 onInput={ this.setVariableName }
-                placeholder={ 'name' }
+                placeholder={ this._translate('name') }
                 value={ name || '' } />
             </td>
           </tr>


### PR DESCRIPTION
Hello everyone. I'm not a JavaScript developer and this is my first time working with node.js. The changes in this pr pass `npm run all` and are visible in `npm run start:translate`. Please let me know if you see any issues.

---

Three dmn-js ui labels are not translatable. This pr makes them translatable. 

Closes #793

## Added Translations
### Decision Table
* Decision Editor
  * "Add Rule"
  * "Move rule"
### Literal Expression
* Literal Expression Editor
  * "name"

