### PR TITLE
feat(label-editing): hide labels while editing

### DIFF
--- a/packages/dmn-js-drd/src/features/label-editing/LabelEditingProvider.js
+++ b/packages/dmn-js-drd/src/features/label-editing/LabelEditingProvider.js
@@ -9,6 +9,7 @@ import {
   isDefined
 } from 'min-dash';
 
+var MARKER_LABEL_HIDDEN = 'djs-label-hidden';
 
 export default function LabelEditingProvider(
     canvas,
@@ -21,6 +22,7 @@ export default function LabelEditingProvider(
   this._canvas = canvas;
   this._modeling = modeling;
   this._textRenderer = textRenderer;
+  this._eventBus = eventBus;
 
   directEditing.registerProvider(this);
 
@@ -64,6 +66,17 @@ export default function LabelEditingProvider(
 
   eventBus.on('autoPlace.end', 500, function(event) {
     directEditing.activate(event.shape);
+  });
+
+  this._eventBus.on([
+    'directEditing.complete', 'directEditing.cancel'
+  ], function(context) {
+    var activeProvider = context.active;
+
+    if (activeProvider) {
+      var element = activeProvider.element.label || activeProvider.element;
+      canvas.removeMarker(element, MARKER_LABEL_HIDDEN);
+    }
   });
 }
 
@@ -118,6 +131,8 @@ LabelEditingProvider.prototype.activate = function(element) {
   assign(context, {
     options: options
   });
+
+  this._canvas.addMarker(element, MARKER_LABEL_HIDDEN);
 
   return context;
 };

--- a/packages/dmn-js-drd/test/spec/features/label-editing/LabelEditingProviderSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/label-editing/LabelEditingProviderSpec.js
@@ -528,6 +528,57 @@ describe('features - label-editing', function() {
 
   });
 
+
+  describe('hiding labels', function() {
+
+    it('should hide label when editing', inject(
+      function(elementRegistry, directEditing, canvas, eventBus) {
+
+        // given
+        var shape = elementRegistry.get('dish-decision');
+
+        // when
+        directEditing.activate(shape);
+
+        // then
+        expect(canvas.hasMarker(shape, 'djs-label-hidden')).to.be.true;
+      }
+    ));
+
+
+    it('should show label when editing cancled', inject(
+      function(elementRegistry, directEditing, canvas, eventBus) {
+
+        // given
+        var shape = elementRegistry.get('dish-decision');
+        directEditing.activate(shape);
+
+        // when
+        directEditing.cancel();
+
+        // then
+        expect(canvas.hasMarker(shape, 'djs-label-hidden')).to.be.false;
+      }
+    ));
+
+
+    it('should show label when editing finished', inject(
+      function(elementRegistry, directEditing, canvas, eventBus) {
+
+        // given
+        var shape = elementRegistry.get('dish-decision');
+        directEditing.activate(shape);
+
+        // when
+        directEditing.complete();
+
+        // then
+        expect(canvas.hasMarker(shape, 'djs-label-hidden')).to.be.false;
+      }
+    ));
+
+  });
+
 });
 
 // helpers //////////


### PR DESCRIPTION
related to https://github.com/bpmn-io/diagram-js-direct-editing/issues/23

This PR ensures we hide the labels on the diagram when direct editing is active. This aligns the [behavior with bpmn-js](https://github.com/bpmn-io/bpmn-js/blob/07f75f7cd5d2ef9934d7b32cccfee6d4f05b8fc6/lib/features/label-editing/LabelEditingPreview.js#L76-L84) and enables us to remove the white background in https://github.com/bpmn-io/diagram-js-direct-editing/issues/23

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
