### PR TITLE
test: use spy to check if variables were retrieved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21395,7 +21395,6 @@
         "table-js": "^9.1.0"
       },
       "devDependencies": {
-        "@testing-library/dom": "^10.1.0",
         "dmn-font": "^0.6.2",
         "inferno-test-utils": "~5.6.2"
       }
@@ -27368,7 +27367,6 @@
       "version": "file:packages/dmn-js-literal-expression",
       "requires": {
         "@bpmn-io/dmn-variable-resolver": "^0.5.0",
-        "@testing-library/dom": "^10.1.0",
         "diagram-js": "^14.5.4",
         "dmn-font": "^0.6.2",
         "dmn-js-shared": "^16.3.2",

--- a/packages/dmn-js-literal-expression/package.json
+++ b/packages/dmn-js-literal-expression/package.json
@@ -26,7 +26,6 @@
     "literal expression"
   ],
   "devDependencies": {
-    "@testing-library/dom": "^10.1.0",
     "dmn-font": "^0.6.2",
     "inferno-test-utils": "~5.6.2"
   },


### PR DESCRIPTION
We can't reliably ensure that the autocompletion opens in tests, so this solution makes the test use a mock variable resolver instead.

Closes #873

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
