### PR TITLE
fix(shared): show FEEL expressions with line wrapping

### DIFF
--- a/packages/dmn-js-shared/src/components/LiteralExpression.js
+++ b/packages/dmn-js-shared/src/components/LiteralExpression.js
@@ -2,6 +2,8 @@ import { Component } from 'inferno';
 
 import FeelEditor from '@bpmn-io/feel-editor';
 
+import { EditorView } from '@codemirror/view';
+
 /**
  * A drop-in replacement for ContentEditable which uses FEEL editor under the hood.
  * It does not support placeholder.
@@ -52,6 +54,9 @@ export default class LiteralExpression extends Component {
       onChange: this.handleChange,
       value: this.state.value,
       variables: this.props.variables || [],
+      extensions: [
+        EditorView.lineWrapping
+      ]
     });
 
     this.node.addEventListener('mousedown', this.handleMouseEvent);


### PR DESCRIPTION
Simple enough fix!

![capture 9oaDSC_optimized](https://github.com/bpmn-io/dmn-js/assets/58601/0c3916f6-5785-4f48-8ae8-d800ec9c853e)

Closes #838