### PR TITLE
feat: add edit input/output button

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
@@ -15,6 +15,11 @@
   --drag-and-drop-handle-hover-color: var(--color-grey-225-10-15);
   --form-control-label-color: var(--color-grey-225-10-15);
   --hint-color: var(--color-grey-225-10-15);
+  --edit-button-color: var(--color-grey-225-10-15);
+  --edit-button-background-color: var(--color-grey-225-10-97);
+  --edit-button-border-color: var(--color-grey-225-10-75);
+  --edit-button-box-shadow-color: var(--color-black-opacity-10);
+  --edit-button-disabled-color: var(--color-grey-225-10-75);
 }
 
 /* simple string edit */
@@ -263,4 +268,28 @@
 
 .dmn-decision-table-container .cell-editor .feel-editor.focussed > :nth-child(2) {
   display: none;
+}
+
+/* edit-button */
+
+.dmn-decision-table-container .edit-button {
+  color: var(--edit-button-color);
+  background-color: var(--edit-button-background-color);
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  padding: 4px;
+  border-radius: 2px;
+  border: solid 1px var(--edit-button-border-color);
+  font-size: var(--font-size);
+  box-shadow: 1px 1px 1px 1px var(--edit-button-box-shadow-color);
+}
+
+.dmn-decision-table-container :not(:focus-within) .edit-button {
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/InputEditingProvider.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/InputEditingProvider.js
@@ -4,6 +4,7 @@ import {
 
 import InputCell from './components/InputCell';
 import InputCellContextMenu from './components/InputCellContextMenu';
+import { InputEditButton } from './components/InputEditButton';
 
 
 export default class InputCellProvider {
@@ -21,6 +22,16 @@ export default class InputCellProvider {
         context.contextMenuType === 'input-edit'
       ) {
         return InputCellContextMenu;
+      }
+    });
+
+    components.onGetComponent('cell-inner', (context = {}) => {
+      const { cellType } = context;
+
+      if (
+        cellType === 'input-cell'
+      ) {
+        return InputEditButton;
       }
     });
 

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/OutputEditingProvider.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/OutputEditingProvider.js
@@ -5,6 +5,7 @@ import {
 
 import OutputCell from './components/OutputCell';
 import OutputCellContextMenu from './components/OutputCellContextMenu';
+import { OutputEditButton } from './components/OutputEditButton';
 
 
 export default class OutputEditingProvider {
@@ -22,6 +23,16 @@ export default class OutputEditingProvider {
         context.contextMenuType === 'output-edit'
       ) {
         return OutputCellContextMenu;
+      }
+    });
+
+    components.onGetComponent('cell-inner', (context = {}) => {
+      const { cellType } = context;
+
+      if (
+        cellType === 'output-cell'
+      ) {
+        return OutputEditButton;
       }
     });
 

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditButton.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/InputEditButton.js
@@ -1,0 +1,29 @@
+import { Component } from 'inferno';
+
+export class InputEditButton extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+
+    this._translate = context.injector.get('translate');
+    this._eventBus = context.injector.get('eventBus');
+  }
+
+  onClick = (event) => {
+    const { col: input } = this.props;
+
+    this._eventBus.fire('input.edit', {
+      event,
+      input
+    });
+  };
+
+  render() {
+    return <button
+      aria-label={ this._translate('Edit input') }
+      type="button"
+      className="edit-button dmn-icon-edit"
+      onClick={ this.onClick }
+    />;
+  }
+}

--- a/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputEditButton.js
+++ b/packages/dmn-js-decision-table/src/features/decision-table-head/editor/components/OutputEditButton.js
@@ -1,0 +1,29 @@
+import { Component } from 'inferno';
+
+export class OutputEditButton extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+
+    this._translate = context.injector.get('translate');
+    this._eventBus = context.injector.get('eventBus');
+  }
+
+  onClick = (event) => {
+    const { col: output } = this.props;
+
+    this._eventBus.fire('output.edit', {
+      event,
+      output
+    });
+  };
+
+  render() {
+    return <button
+      aria-label={ this._translate('Edit output') }
+      type="button"
+      className="edit-button dmn-icon-edit"
+      onClick={ this.onClick }
+    />;
+  }
+}


### PR DESCRIPTION
### Proposed Changes

Run `npx @bpmn-io/sr bpmn-io/dmn-js#845-edit-button-for-decision-table-head` to try this out locally.

The button is visually hidden unless focussed with keyboard.

Closes #845


https://github.com/bpmn-io/dmn-js/assets/28307541/87b0de58-5779-40a1-b436-09158ea2ff25



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
