### PR TITLE
feat(drd): add `Modeling#updateModdleProperties`

### DIFF
--- a/packages/dmn-js-drd/src/features/modeling/Modeling.js
+++ b/packages/dmn-js-drd/src/features/modeling/Modeling.js
@@ -5,6 +5,7 @@ import BaseModeling from 'diagram-js/lib/features/modeling/Modeling';
 import IdClaimHandler from './cmd/IdClaimHandler.js';
 import UpdateLabelHandler from '../label-editing/cmd/UpdateLabelHandler.js';
 import UpdatePropertiesHandler from './cmd/UpdatePropertiesHandler.js';
+import UpdateModdlePropertiesHandler from './cmd/UpdateModdlePropertiesHandler.js';
 
 
 /**
@@ -60,6 +61,7 @@ Modeling.prototype.getHandlers = function() {
   handlers['id.updateClaim'] = IdClaimHandler;
   handlers['element.updateLabel'] = UpdateLabelHandler;
   handlers['element.updateProperties'] = UpdatePropertiesHandler;
+  handlers['element.updateModdleProperties'] = UpdateModdlePropertiesHandler;
 
   return handlers;
 };
@@ -68,6 +70,14 @@ Modeling.prototype.unclaimId = function(id, moddleElement) {
   this._commandStack.execute('id.updateClaim', {
     id: id,
     element: moddleElement
+  });
+};
+
+Modeling.prototype.updateModdleProperties = function(element, moddleElement, properties) {
+  this._commandStack.execute('element.updateModdleProperties', {
+    element: element,
+    moddleElement: moddleElement,
+    properties: properties
   });
 };
 

--- a/packages/dmn-js-drd/src/features/modeling/cmd/UpdateModdlePropertiesHandler.js
+++ b/packages/dmn-js-drd/src/features/modeling/cmd/UpdateModdlePropertiesHandler.js
@@ -1,0 +1,62 @@
+import {
+  reduce,
+  keys,
+  forEach
+} from 'min-dash';
+
+export default function UpdateModdlePropertiesHandler(elementRegistry) {
+  this._elementRegistry = elementRegistry;
+}
+
+UpdateModdlePropertiesHandler.$inject = [ 'elementRegistry' ];
+
+UpdateModdlePropertiesHandler.prototype.execute = function(context) {
+
+  var element = context.element,
+      moddleElement = context.moddleElement,
+      properties = context.properties;
+
+  if (!moddleElement) {
+    throw new Error('<moddleElement> required');
+  }
+
+  // TODO(nikku): we need to ensure that ID properties
+  // are properly registered / unregistered via
+  // this._moddle.ids.assigned(id)
+  var changed = context.changed || [ element ];
+  var oldProperties = context.oldProperties
+    || getModdleProperties(moddleElement, keys(properties));
+
+  setModdleProperties(moddleElement, properties);
+
+  context.oldProperties = oldProperties;
+  context.changed = changed;
+
+  return changed;
+};
+
+UpdateModdlePropertiesHandler.prototype.revert = function(context) {
+  var oldProperties = context.oldProperties,
+      moddleElement = context.moddleElement,
+      changed = context.changed;
+
+  setModdleProperties(moddleElement, oldProperties);
+
+  return changed;
+};
+
+
+// helpers /////////////////
+
+function getModdleProperties(moddleElement, propertyNames) {
+  return reduce(propertyNames, function(result, key) {
+    result[key] = moddleElement.get(key);
+    return result;
+  }, {});
+}
+
+function setModdleProperties(moddleElement, properties) {
+  forEach(properties, function(value, key) {
+    moddleElement.set(key, value);
+  });
+}

--- a/packages/dmn-js-drd/test/spec/features/modeling/UpdateModdleProperties.dmn
+++ b/packages/dmn-js-drd/test/spec/features/modeling/UpdateModdleProperties.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_075f9cc">
+      <input id="Input_1">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/modeling/UpdateModdlePropertiesSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/UpdateModdlePropertiesSpec.js
@@ -1,0 +1,56 @@
+/* global sinon */
+
+import { getBusinessObject } from 'dmn-js-shared/lib/util/ModelUtil';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import modelingModule from 'src/features/modeling';
+import coreModule from 'src/core';
+
+var testModules = [ coreModule, modelingModule ];
+
+
+describe('features/modeling - update moddle properties', function() {
+
+  describe('updating dmn:Decision', function() {
+
+    var diagramXML = require('./UpdateModdleProperties.dmn');
+
+    beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+    it('should update', inject(function(elementRegistry, modeling, eventBus) {
+
+      // given
+      var decision = elementRegistry.get('Decision_1'),
+          businessObject = getBusinessObject(decision);
+
+      var changedElements;
+
+      var elementsChangedListener = sinon.spy(function(event) {
+        changedElements = event.elements;
+      });
+
+      eventBus.on('elements.changed', elementsChangedListener);
+
+      // assume
+      expect(businessObject.get('name')).to.eql('Decision 1');
+
+      // when
+      modeling.updateModdleProperties(decision, businessObject, { name: 'Decision 2' });
+
+      // then
+      expect(businessObject.get('name')).to.eql('Decision 2');
+
+      // changed affected elements
+      expect(changedElements).to.eql([
+        decision
+      ]);
+    }));
+
+  });
+
+});

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+## 16.6.0
+
+* `FEAT`: add `Modeling#updateModdleProperties` ([#886](https://github.com/bpmn-io/dmn-js/pull/886))
+
 ## 16.5.0
 
 * `FEAT`: add edit input/output button ([#845](https://github.com/bpmn-io/dmn-js/issues/845))


### PR DESCRIPTION
### Proposed Changes

Adds `Modeling#updateModdleProperties` mirroring [bpmn-js](https://github.com/bpmn-io/bpmn-js/blob/develop/lib/features/modeling/Modeling.js#L144).

This is needed in the context of https://github.com/camunda/product-hub/issues/435 as users need to be able add a version tag to a decision through the properties panel. Since the version tag is an extension element we need `updateModdleProperties`.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
