### PR TITLE
fix: edit button does not flash when adding new column

### DIFF
--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
@@ -256,7 +256,7 @@
 }
 
 /* cell editor */
-.dmn-decision-table-container .cell-editor:focus-visible .dmn-expression-language {
+.dmn-decision-table-container .cell-editor:focus-within .dmn-expression-language {
   display: none;
 }
 

--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
@@ -285,8 +285,7 @@
   box-shadow: 1px 1px 1px 1px var(--edit-button-box-shadow-color);
 }
 
-.dmn-decision-table-container :not(:focus-within) .edit-button,
-.dmn-decision-table-container :has(.dmn-icon-plus:active) .edit-button {
+.dmn-decision-table-container :not(:has(:focus-visible)) .edit-button {
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;

--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
@@ -285,7 +285,8 @@
   box-shadow: 1px 1px 1px 1px var(--edit-button-box-shadow-color);
 }
 
-.dmn-decision-table-container :not(:focus-visible) .edit-button {
+.dmn-decision-table-container :not(:focus-within) .edit-button,
+.dmn-decision-table-container :has(.dmn-icon-plus:active) .edit-button {
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;

--- a/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
+++ b/packages/dmn-js-decision-table/assets/css/dmn-js-decision-table-controls.css
@@ -256,7 +256,7 @@
 }
 
 /* cell editor */
-.dmn-decision-table-container .cell-editor:focus-within .dmn-expression-language {
+.dmn-decision-table-container .cell-editor:focus-visible .dmn-expression-language {
   display: none;
 }
 
@@ -285,7 +285,7 @@
   box-shadow: 1px 1px 1px 1px var(--edit-button-box-shadow-color);
 }
 
-.dmn-decision-table-container :not(:focus-within) .edit-button {
+.dmn-decision-table-container :not(:focus-visible) .edit-button {
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;


### PR DESCRIPTION
### Proposed Changes

Fix for flashing edit button when adding a new column.

Related https://github.com/camunda/camunda-modeler/issues/4388

https://github.com/user-attachments/assets/259bc300-69e2-49cc-841c-0861e4a37a6d

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
