### PR TITLE
fix: fix literal expression editor hitbox in BKM

### DIFF
--- a/packages/dmn-js-boxed-expression/assets/css/dmn-js-boxed-expression.css
+++ b/packages/dmn-js-boxed-expression/assets/css/dmn-js-boxed-expression.css
@@ -104,6 +104,7 @@
 }
 
 .dmn-boxed-expression-container .textarea.editor {
+  height: 100%;
   cursor: text;
 }
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4545
Follow up for the same issue in the decision table: https://github.com/camunda/camunda-modeler/issues/4342

### Proposed Changes

Literal expression editor in BKM now takes full parent height.

https://github.com/user-attachments/assets/f6cd2b7a-bb17-4ae4-a32e-412e8ebcca86


<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [X] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
