### PR TITLE
fix: make literal expression variables table styles explicit

### DIFF
--- a/packages/dmn-js-literal-expression/assets/css/dmn-js-literal-expression.css
+++ b/packages/dmn-js-literal-expression/assets/css/dmn-js-literal-expression.css
@@ -128,6 +128,7 @@
 
 .dmn-literal-expression-container .literal-expression-properties table {
   border-spacing: 8px;
+  border-collapse: separate;
 }
 
 .dmn-literal-expression-container .literal-expression-properties table tr td:first-child {

--- a/packages/dmn-js-literal-expression/assets/css/dmn-js-literal-expression.css
+++ b/packages/dmn-js-literal-expression/assets/css/dmn-js-literal-expression.css
@@ -126,16 +126,16 @@
   color: var(--literal-expression-properties-color);
 }
 
-.dmn-literal-expression-container .literal-expression-properties table {
+.dmn-literal-expression-container .literal-expression-properties .variables-table {
   border-spacing: 8px;
   border-collapse: separate;
 }
 
-.dmn-literal-expression-container .literal-expression-properties table tr td:first-child {
+.dmn-literal-expression-container .literal-expression-properties .variables-table tr td:first-child {
   font-weight: bold;
 }
 
-.dmn-literal-expression-container .literal-expression-properties table tr td:last-child {
+.dmn-literal-expression-container .literal-expression-properties .variables-table tr td:last-child {
   min-width: 100px;
 }
 

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
@@ -77,7 +77,7 @@ export default class LiteralExpressionPropertiesComponent extends Component {
 
     return (
       <div className="literal-expression-properties">
-        <table>
+        <table className="variables-table">
           <tr>
             <td>{ this._translate('Variable name:') }</td>
             <td>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4550

### Proposed Changes

Add explicit styles for the table and make them into a class to prevent being overridden.

Possible a topic for further discussion as described here: https://github.com/bpmn-io/variable-outline/issues/4

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
