### PR TITLE
Prevent global `keydown` event when `ContentEditable` handled `ENTER`

### DIFF
--- a/packages/dmn-js-shared/src/components/ContentEditable.js
+++ b/packages/dmn-js-shared/src/components/ContentEditable.js
@@ -243,11 +243,11 @@ export default class ContentEditable extends Component {
         spellCheck="false"
         data-placeholder={ placeholder || '' }
         onInput={ this.onInput }
-        onkeypress={ this.onkeypress }
+        onkeypress={ this.onkeypress } // intentionally lowercase to use native event
         onPaste={ this.onPaste }
         onFocus={ this.onFocus }
         onBlur={ this.onBlur }
-        onkeydown={ this.onkeydown }
+        onkeydown={ this.onkeydown } // intentionally lowercase to use native event
         ref={ node => this.node = node }
         dangerouslySetInnerHTML={ { __html: value } }></div>
     );

--- a/packages/dmn-js-shared/src/components/ContentEditable.js
+++ b/packages/dmn-js-shared/src/components/ContentEditable.js
@@ -143,7 +143,7 @@ export default class ContentEditable extends Component {
     }
   };
 
-  onKeydown = (event) => {
+  onkeydown = (event) => {
 
     // enter
     if (event.which === 13) {
@@ -182,7 +182,7 @@ export default class ContentEditable extends Component {
   };
 
   // TODO(barmac): remove once we drop IE 11 support
-  onKeyPress = (event) => {
+  onkeypress = (event) => {
     if (this.onInputIEPolyfill) {
       this.onInputIEPolyfill(event);
     }
@@ -243,11 +243,11 @@ export default class ContentEditable extends Component {
         spellCheck="false"
         data-placeholder={ placeholder || '' }
         onInput={ this.onInput }
-        onKeyPress={ this.onKeypress }
+        onkeypress={ this.onkeypress }
         onPaste={ this.onPaste }
         onFocus={ this.onFocus }
         onBlur={ this.onBlur }
-        onKeyDown={ this.onKeydown }
+        onkeydown={ this.onkeydown }
         ref={ node => this.node = node }
         dangerouslySetInnerHTML={ { __html: value } }></div>
     );


### PR DESCRIPTION


### Proposed Changes

This fixes a regression introduced via a6dfc16b9cd6ebf56da14b532ccca728550cb0d8.

The prior change switched to `onKeyDown`, which is an synthetic event handler that cannot prevent default (on global clicks).

What we need to prevent default (global) clicks is actual DOM event handling. Quoting from the Inferno documentation [1]:

> Lower case events will bypass Inferno's event system in favour of
> using the native event system supplied by the browser.

[1]: https://www.infernojs.org/docs/guides/event-handling

---

The fixed behavior can be inspected via `npm start`, using the Dish Decision `JavaScript` field, but also in the fact that the test suite passes (again):

![capture he9DAr_optimized](https://github.com/user-attachments/assets/2fb15d95-09fb-4ef9-82fb-e6891906f628)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
