### PR TITLE
chore: make dmn-js-builder more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dmn-js-build",
-  "version": "1.1.0",
+  "name": "dmn-js-builder",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "all": "run-s lint build test",


### PR DESCRIPTION
### Proposed Changes

Make `dmn-js-builder` more explicit about not being something we want to release to public. If _somebody_ tries to release with `np` there should be some good indication that this is not what they actually desire to do:

<img width="401" alt="image" src="https://github.com/user-attachments/assets/87c4fceb-6c45-4ed5-96a3-a7d0b37ea0cb">

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
