### PR TITLE
Formal parameters sync with literal expression 

### DIFF
--- a/packages/dmn-js-boxed-expression/src/features/function-definition/components/FunctionDefinitionEditorComponent.js
+++ b/packages/dmn-js-boxed-expression/src/features/function-definition/components/FunctionDefinitionEditorComponent.js
@@ -20,6 +20,7 @@ const FunctionDefinitionEditorComponent = withChangeSupport(
   props => [ props.expression ]
 );
 
+
 function _FunctionDefinitionEditorComponent({ expression }, context) {
   const functionDefinition = context.injector.get('functionDefinition');
   const contextMenu = context.injector.get('contextMenu');
@@ -50,7 +51,7 @@ function _FunctionDefinitionEditorComponent({ expression }, context) {
         parameters={ parameters }
         openEditor={ openFormalParametersEditor }
       />
-      <BodyExpression expression={ body } />
+      <BodyExpression expression={ body } parameters={ parameters } />
     </div>
   );
 }
@@ -102,14 +103,18 @@ function _Parameter({ parameter }) {
   </span>;
 }
 
-function BodyExpression({ expression }, context) {
+const BodyExpression = withChangeSupport(_BodyExpression, props => props.parameters);
+
+function _BodyExpression({ expression, parameters }, context) {
   const Expression = context.components.getComponent('expression', {
     expression
   });
 
+  console.log('parameters BodyExpression: ', parameters);
+
   return (
     <div className="function-definition-body">
-      <Expression expression={ expression } />
+      <Expression expression={ expression } parameters={ parameters } />
     </div>
   );
 }


### PR DESCRIPTION
Closes #896 
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

You can update the parameters and the variables will be available in real-time in literal expression.
![Nov-05-2024 15-37-49](https://github.com/user-attachments/assets/95b08704-f71d-4b94-9f1e-dce326d8922a)



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
