### PR TITLE
fix: make name change behavior not break on name change

### DIFF
--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/NameChangeBehaviorSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/NameChangeBehaviorSpec.js
@@ -6,7 +6,7 @@ import CoreModule from 'src/core';
 import Modeling from 'src/features/modeling';
 
 
-describe('NameChangeBehavior', function() {
+describe('features/modeling - NameChangeBehavior', function() {
 
   beforeEach(bootstrapModeler(simpleStringEditXML, {
     modules: [

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/NameChangeBehaviorSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/NameChangeBehaviorSpec.js
@@ -8,66 +8,117 @@ import Modeling from 'src/features/modeling';
 
 describe('NameChangeBehavior', function() {
 
-  describe('with label change', function() {
-
-    beforeEach(bootstrapModeler(simpleStringEditXML, {
-      modules: [
-        CoreModule,
-        Modeling
-      ],
-    }));
-
-    describe('should update variable name when label is changed', function() {
+  beforeEach(bootstrapModeler(simpleStringEditXML, {
+    modules: [
+      CoreModule,
+      Modeling
+    ],
+  }));
 
 
-      it('<do>', inject(
-        function(modeling, elementRegistry) {
+  describe('should update variable name when label is changed', function() {
 
-          // given
-          const decision = elementRegistry.get('season'),
-                bo = decision.businessObject,
-                variable = bo.variable;
-
-          // when
-          modeling.updateLabel(decision,'foo');
-
-          // then
-          expect(variable.get('name')).to.equal('foo');
-        }
-      ));
-
-
-      it('<undo>', inject(function(modeling, elementRegistry, commandStack) {
+    it('<do>', inject(
+      function(modeling, elementRegistry) {
 
         // given
         const decision = elementRegistry.get('season'),
               bo = decision.businessObject,
               variable = bo.variable;
-        modeling.updateLabel(decision,'foo');
 
         // when
-        commandStack.undo();
-
-        // then
-        expect(variable.get('name')).to.equal('season');
-      }));
-
-
-      it('<redo>', inject(function(modeling, elementRegistry, commandStack) {
-
-        // given
-        const decision = elementRegistry.get('season'),
-              bo = decision.businessObject,
-              variable = bo.variable;
         modeling.updateLabel(decision,'foo');
-
-        // when
-        commandStack.undo();
-        commandStack.redo();
 
         // then
         expect(variable.get('name')).to.equal('foo');
-      }));
-    });
+      }
+    ));
+
+
+    it('<undo>', inject(function(modeling, elementRegistry, commandStack) {
+
+      // given
+      const decision = elementRegistry.get('season'),
+            bo = decision.businessObject,
+            variable = bo.variable;
+      modeling.updateLabel(decision,'foo');
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(variable.get('name')).to.equal('season');
+    }));
+
+
+    it('<redo>', inject(function(modeling, elementRegistry, commandStack) {
+
+      // given
+      const decision = elementRegistry.get('season'),
+            bo = decision.businessObject,
+            variable = bo.variable;
+      modeling.updateLabel(decision,'foo');
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(variable.get('name')).to.equal('foo');
+    }));
+  });
+
+
+  describe('should update variable name when element name is changed', function() {
+
+
+    it('<do>', inject(
+      function(modeling, elementRegistry) {
+
+        // given
+        const decision = elementRegistry.get('season'),
+              bo = decision.businessObject,
+              variable = bo.variable;
+
+        // when
+        modeling.updateProperties(decision, { name: 'foo' });
+
+        // then
+        expect(variable.get('name')).to.equal('foo');
+      }
+    ));
+
+
+    it('<undo>', inject(function(modeling, elementRegistry, commandStack) {
+
+      // given
+      const decision = elementRegistry.get('season'),
+            bo = decision.businessObject,
+            variable = bo.variable;
+      modeling.updateProperties(decision, { name: 'foo' });
+
+      // when
+      commandStack.undo();
+
+      // then
+      expect(variable.get('name')).to.equal('season');
+    }));
+
+
+    it('<redo>', inject(function(modeling, elementRegistry, commandStack) {
+
+      // given
+      const decision = elementRegistry.get('season'),
+            bo = decision.businessObject,
+            variable = bo.variable;
+      modeling.updateProperties(decision, { name: 'foo' });
+
+      // when
+      commandStack.undo();
+      commandStack.redo();
+
+      // then
+      expect(variable.get('name')).to.equal('foo');
+    }));
   });
 });

--- a/packages/dmn-js-shared/src/features/modeling/behavior/NameChangeBehavior.js
+++ b/packages/dmn-js-shared/src/features/modeling/behavior/NameChangeBehavior.js
@@ -51,7 +51,7 @@ export default class NameChangeBehavior extends CommandInterceptor {
       return;
     }
 
-    else if (!this.isElementVariable(element)) {
+    else if (!this.shouldSyncVariable(element)) {
       this.syncElementVariableChange(bo);
     }
   };
@@ -68,9 +68,10 @@ export default class NameChangeBehavior extends CommandInterceptor {
     );
   }
 
-  isElementVariable(element) {
-    const variable = element.get('variable');
-    return variable && (element.name === variable.name);
+  shouldSyncVariable(element) {
+    const bo = getBusinessObject(element),
+          variable = bo.get('variable');
+    return variable && (bo.name === variable.name);
   }
 
   syncElementVariableChange(businessObject) {


### PR DESCRIPTION
### Proposed Changes

https://github.com/user-attachments/assets/73f5fbd9-1ead-4cbb-81fd-8c2dcc6644c1

We've tested the label update but not the direct name change with `modeling.updateProperties`. Now we test for both.

Related to https://github.com/bpmn-io/dmn-js-properties-panel/issues/103 
Related to https://github.com/camunda/camunda-modeler/issues/4684

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
