### PR TITLE
Add delete action for multi element context

### DIFF
--- a/packages/dmn-js-drd/src/features/context-pad/ContextPadProvider.js
+++ b/packages/dmn-js-drd/src/features/context-pad/ContextPadProvider.js
@@ -1,5 +1,6 @@
 import {
   assign,
+  every,
   isArray
 } from 'min-dash';
 
@@ -297,3 +298,43 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
   return actions;
 };
+
+ContextPadProvider.prototype.getMultiElementContextPadEntries = function(
+    elements
+) {
+  var modeling = this._modeling,
+      translate = this._translate;
+
+  var actions = {};
+
+  if (this._isDeleteAllowed(elements)) {
+    assign(actions, {
+      'delete': {
+        group: 'edit',
+        className: 'dmn-icon-trash',
+        title: translate('Delete'),
+        action: {
+          click: (e, elements) => modeling.removeElements(elements.slice())
+        },
+      },
+    });
+  }
+
+  return actions;
+};
+
+ContextPadProvider.prototype._isDeleteAllowed = function(elements) {
+
+  // rules allowed can return boolean or array of elements (not reflected in type )
+  var allowedOrAllowedElements = this._rules.allowed('elements.delete', {
+    elements: elements
+  });
+
+  if (isArray(allowedOrAllowedElements)) {
+    return every(elements, el => allowedOrAllowedElements.includes(el));
+  }
+
+  return allowedOrAllowedElements;
+};
+
+

--- a/packages/dmn-js-drd/test/spec/features/context-pad/ContextPadProviderSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/context-pad/ContextPadProviderSpec.js
@@ -166,6 +166,64 @@ describe('features - context-pad', function() {
       })
     );
 
+
+    describe('multi remove', function() {
+
+      it('should add delete action by default', inject(
+        function(elementRegistry, contextPad) {
+
+          // given
+          var shape1 = elementRegistry.get('dayType_id'),
+              shape2 = elementRegistry.get('temperature_id');
+
+          // when
+          contextPad.open([ shape1, shape2 ]);
+
+          // then
+          expect(deleteAction([ shape1, shape2 ])).to.exist;
+        }
+      ));
+
+
+      it('should NOT add delete action when rule returns false', inject(
+        function(elementRegistry, contextPad, customRules) {
+
+          // given
+          customRules.addRule('elements.delete', 1500, function() {
+            return false;
+          });
+
+          var shape1 = elementRegistry.get('dayType_id'),
+              shape2 = elementRegistry.get('temperature_id');
+
+          // when
+          contextPad.open([ shape1, shape2 ]);
+
+          // then
+          expect(deleteAction([ shape1, shape2 ])).not.to.exist;
+        }
+      ));
+
+
+      it('should trigger batch delete', inject(
+        function(elementRegistry, contextPad, customRules) {
+
+          // given
+          var shape1 = elementRegistry.get('dayType_id'),
+              shape2 = elementRegistry.get('temperature_id');
+
+          contextPad.open([ shape1, shape2 ]);
+
+          // when
+          contextPad.trigger('click', padEvent('delete'));
+
+          // then
+          expect(elementRegistry.get('dayType_id')).not.to.exist;
+          expect(elementRegistry.get('temperature_id')).not.to.exist;
+        }
+      ));
+
+    });
   });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4554

### Proposed Changes

Adds ContextPad actions for multi selections. The only action added for now is the delete action. Selecting multiple shapes and deleting with keyboard also works.

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

https://github.com/user-attachments/assets/162a86f2-d71e-4e40-bb5b-d7046652cb2e



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`


<!--

Thanks for creating this pull request! ❤️

-->
