### PR TITLE
setup local path alias for easier code navigation in ide

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "dmn-js-boxed-expression": [ "./packages/dmn-js-boxed-expression/src", "./packages/dmn-js-boxed-expression/lib", "./node_modules/dmn-js-boxed-expression" ],
+
+      "dmn-js/lib/*": [ "./packages/dmn-js/src/*", "./packages/dmn-js/lib/*", "./node_modules/dmn-js/lib/*" ],
+      "dmn-js-decision-table/lib/*": [ "./packages/dmn-js-decision-table/src/*", "./packages/dmn-js-decision-table/lib/*", "./node_modules/dmn-js-decision-table/lib/*" ],
+      "dmn-js-drd/lib/*": [ "./packages/dmn-js-drd/src/*", "./packages/dmn-js-drd/lib/*", "./node_modules/dmn-js-drd/lib/*" ],
+      "dmn-js-literal-expression/lib/*": [ "./packages/dmn-js-literal-expression/src/*", "./packages/dmn-js-literal-expression/lib/*", "./node_modules/dmn-js-literal-expression/lib/*" ],
+      "dmn-js-shared/lib/*": [ "./packages/dmn-js-shared/src/*", "./packages/dmn-js-shared/lib/*", "./node_modules/dmn-js-shared/lib/*" ],
+    }
+  }
+}


### PR DESCRIPTION
### Proposed Changes

Use [jsconfing.json](https://code.visualstudio.com/docs/languages/jsconfig) to give IDEs with [LSP support](https://langserver.org/#implementations-client) (eg. vscode) a hint were to find source files. This allows easier navigation directly to the `src` and not accidentally editing files in `lib`.

`dmn-js-boxed-expression` seems to only be imported as a module so it has a slightly different path alias than the other dmn-js packages wich import dircectly by path.

### Alternative

Provide example jsconfig.json in docs and everyone can add them locally and add that to a global `.gitignore` file to not pollute the repo with IDE specific configs

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
