### PR TITLE
fix: cursor jumps when editing definition properties

### DIFF
--- a/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesView.js
+++ b/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesView.js
@@ -68,8 +68,13 @@ DefinitionPropertiesView.prototype._init = function() {
 DefinitionPropertiesView.prototype.update = function() {
   var businessObject = this._canvas.getRootElement().businessObject;
 
-  this.nameElement.textContent = businessObject.name;
-  this.idElement.textContent = businessObject.id;
+  if (document.activeElement !== this.nameElement) {
+    this.nameElement.textContent = businessObject.name;
+  }
+
+  if (document.activeElement !== this.idElement) {
+    this.idElement.textContent = businessObject.id;
+  }
 };
 
 


### PR DESCRIPTION
When definition properties are edited it fires `Modeling#updateProperties`. This method fires command `element.updateProperties` via commandStack to update element, same time `DrdUpdater` is subscribed to this command and do `DefinitionPropertiesView#update` when it executed.

When `DefinitionPropertiesView#update` is called it updates textContent of corresponding elements unconditionally which leads to cursor jump. In order to workaround issue with jumping cursor I've added condition that checks if element currently in focus and if so it prevent update of element content


Fixes #951
Fixes #274

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
