### PR TITLE
ci: add comment on PRs targeting main

### DIFF
--- a/.github/workflows/COMMENT_TARGETS_MAIN.yml
+++ b/.github/workflows/COMMENT_TARGETS_MAIN.yml
@@ -1,0 +1,24 @@
+name: COMMENT_TARGETS_MAIN
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+permissions:
+  pull-requests: write
+jobs:
+  comment:
+    name: Comment on targeting main branch
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Create comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          BODY: |
+            This pull request targets the `main` branch. Please target `main` for bug fixes only. Target `develop` for regular feature development.
+        run: gh issue comment "$NUMBER" --body "$BODY"


### PR DESCRIPTION
Related to bpmn-io/internal-docs#1206

### Proposed Changes

Add a github action that adds a comment if the target branch of a PR is main, (we want to target develop by default).

See for example the comment in this PR. But in this case I actually want to target main directly

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
