### PR TITLE
fix: fix error on keyboard navigation in popups without menu entries

### DIFF
--- a/packages/dmn-js-decision-table/src/features/context-menu/ContextMenuKeyboard.js
+++ b/packages/dmn-js-decision-table/src/features/context-menu/ContextMenuKeyboard.js
@@ -23,6 +23,10 @@ export default class ContextMenuKeyboard {
   };
 
   handleKeyEvent = (event) => {
+    if (!this.getEntries().length) {
+      return;
+    }
+
     if (event.key === 'ArrowUp') {
       event.preventDefault();
       this.move(event.target, -1);
@@ -88,6 +92,11 @@ export default class ContextMenuKeyboard {
 
     if (!current) {
       const next = entries[0];
+
+      if (!next) {
+        return;
+      }
+
       classes(next).add('focused');
       return;
     }

--- a/packages/dmn-js-decision-table/test/spec/features/context-menu/ContextMenuKeyboardSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/context-menu/ContextMenuKeyboardSpec.js
@@ -17,6 +17,8 @@ import CoreModule from 'src/core';
 import InteractionEventsModule from 'table-js/lib/features/interaction-events';
 import ModelingModule from 'src/features/modeling';
 import DecisionRulesModule from 'src/features/decision-rules';
+import DecisionTableHeadModule from 'src/features/decision-table-head';
+import DecisionTableHeadEditorModule from 'src/features/decision-table-head/editor';
 
 describe('context menu keyboard', function() {
 
@@ -25,11 +27,14 @@ describe('context menu keyboard', function() {
     modules: [
       ContextMenuModule,
       CoreModule,
+      DecisionTableHeadModule,
+      DecisionTableHeadEditorModule,
       InteractionEventsModule,
       ModelingModule,
       DecisionRulesModule,
       ContextMenuKeyboard
-    ]
+    ],
+    debounceInput: false
   }));
 
   let testContainer;
@@ -121,14 +126,15 @@ describe('context menu keyboard', function() {
   }));
 
 
-  it('should not throw error when opened without menu entries', inject(function(eventBus) {
+  it('should not throw error on keyboard navigation when menu do not have group entries', inject(function() {
 
     // given
-    // simulate a popup without navigable entries (e.g. input expression editor)
-    eventBus.fire('contextMenu.open', {
-      position: { x: 0, y: 0 },
-      context: { contextMenuType: 'input-edit' }
-    });
+    const cellEl = query('[data-col-id="input1"]', testContainer);
+    triggerMouseEvent(cellEl, 'dblclick');
+
+    // assume
+    expect(query('.context-menu', testContainer)).to.exist;
+    expect(queryAll('.context-menu-group-entry', testContainer)).to.have.length(0);
 
     // when / then
     expect(() => {

--- a/packages/dmn-js-decision-table/test/spec/features/context-menu/ContextMenuKeyboardSpec.js
+++ b/packages/dmn-js-decision-table/test/spec/features/context-menu/ContextMenuKeyboardSpec.js
@@ -119,6 +119,22 @@ describe('context menu keyboard', function() {
     const focusedEntry = query('.context-menu-group-entry.focused', testContainer);
     expect(classes(focusedEntry).contains('disabled')).to.be.false;
   }));
+
+
+  it('should not throw error when opened without menu entries', inject(function(eventBus) {
+
+    // given
+    // simulate a popup without navigable entries (e.g. input expression editor)
+    eventBus.fire('contextMenu.open', {
+      position: { x: 0, y: 0 },
+      context: { contextMenuType: 'input-edit' }
+    });
+
+    // when / then
+    expect(() => {
+      triggerKeyEvent(document, 'keydown', { key: 'ArrowDown' });
+    }).not.to.throw();
+  }));
 });
 
 

--- a/packages/dmn-js/CHANGELOG.md
+++ b/packages/dmn-js/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [dmn-js](https://github.com/bpmn-io/dmn-js) are documente
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: fix error on keyboard navigation in popups without menu entries ([#991](https://github.com/bpmn-io/dmn-js/pull/991))
+
 ## 17.7.0
 
 * `DEPS`: update to `ids@3.0.1`


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4958

### Proposed Changes

Fix error on keyboard navigation in popups without menu entries


https://github.com/user-attachments/assets/0dc46c95-86f1-485f-a7d4-1af36ae00713


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
