### PR TITLE
fix(boxed-expression): allow setting variable on element without one

### DIFF
--- a/packages/dmn-js-boxed-expression/src/features/element-variable/ElementVariableEditor.js
+++ b/packages/dmn-js-boxed-expression/src/features/element-variable/ElementVariableEditor.js
@@ -16,11 +16,13 @@ export default class ElementVariableEditor extends ElementVariable {
     if (!variable) {
       const element = this._getElement();
 
-      this._modeling.updateProperties(element, {
-        variable: this._dmnFactory.create('dmn:InformationItem', {
-          name: element.get('name'), typeRef
-        })
+      const newVariable = this._dmnFactory.create('dmn:InformationItem', {
+        name: element.get('name'), typeRef
       });
+
+      newVariable.$parent = element;
+
+      this._modeling.updateProperties(element, { variable: newVariable });
 
       return;
     }

--- a/packages/dmn-js-boxed-expression/test/spec/features/modeling/ModelingSpec.js
+++ b/packages/dmn-js-boxed-expression/test/spec/features/modeling/ModelingSpec.js
@@ -91,4 +91,71 @@ describe('Modeling', function() {
     expect(viewer.getRootElement().variable.typeRef).to.equal('foo');
   }));
 
+
+  describe('moddle element as value', function() {
+
+    it('should set moddle element on previously-empty property',
+      inject(function(modeling, viewer, moddle) {
+
+        // given
+        const decision = viewer.getRootElement();
+
+        decision.variable = undefined;
+
+        const newVariable = moddle.create('dmn:InformationItem', {
+          name: 'foo',
+          typeRef: 'string'
+        });
+
+        // when
+        modeling.updateProperties(decision, { variable: newVariable });
+
+        // then
+        expect(viewer.getRootElement().variable).to.equal(newVariable);
+      })
+    );
+
+
+    it('should replace moddle element value',
+      inject(function(modeling, viewer, moddle) {
+
+        // given
+        const decision = viewer.getRootElement();
+
+        const newVariable = moddle.create('dmn:InformationItem', {
+          name: 'foo',
+          typeRef: 'string'
+        });
+
+        // when
+        modeling.updateProperties(decision, { variable: newVariable });
+
+        // then
+        expect(viewer.getRootElement().variable).to.equal(newVariable);
+      })
+    );
+  });
+
+
+  describe('container property', function() {
+
+    it('should update nested properties', inject(function(modeling, viewer) {
+
+      // given
+      const decision = viewer.getRootElement();
+
+      // when
+      modeling.updateProperties(decision, {
+        variable: {
+          name: 'foo',
+          typeRef: 'string'
+        }
+      });
+
+      // then
+      expect(viewer.getRootElement().variable.name).to.equal('foo');
+      expect(viewer.getRootElement().variable.typeRef).to.equal('string');
+    }));
+  });
+
 });

--- a/packages/dmn-js-shared/src/features/modeling/cmd/UpdatePropertiesHandler.js
+++ b/packages/dmn-js-shared/src/features/modeling/cmd/UpdatePropertiesHandler.js
@@ -86,10 +86,11 @@ export default class EditPropertiesHandler {
 
       const propertyValue = bo.get(key);
 
-      // handle nested update
+      // handle nested update (plain object), but treat moddle elements
+      // as values to be set directly rather than merged
       if (isContainer(value)) {
 
-        if (!isContainer(propertyValue)) {
+        if (!isModdleElement(propertyValue) && !isContainer(propertyValue)) {
           throw new Error(
             `non-existing property <${key}>: cannot update values`
           );
@@ -150,6 +151,11 @@ function isIdChange(element, newId) {
 function isContainer(o) {
   return (
     isDefined(o) &&
-    isObject(o)
+    isObject(o) &&
+    !isModdleElement(o)
   );
+}
+
+function isModdleElement(o) {
+  return !!o?.$type;
 }


### PR DESCRIPTION
### Proposed Changes

https://github.com/user-attachments/assets/0507c47d-c228-4123-80ae-a429090d0cbd

Treat moddle elements as plain values in UpdatePropertiesHandler instead of merging them as nested containers. Setting a freshly created variable on a BusinessKnowledgeModel that previously had none threw "non-existing property <variable>: cannot update values".

Closes #994

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
