### PR TITLE
fix: Avoid cursor jump when editing definition properties

### DIFF
--- a/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesEdit.js
+++ b/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesEdit.js
@@ -1,10 +1,4 @@
 import {
-  debounce
-} from 'min-dash';
-
-var DEBOUNCE_DELAY = 300;
-
-import {
   domify,
   classes as domClasses,
   query as domQuery

--- a/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesEdit.js
+++ b/packages/dmn-js-drd/src/features/definition-properties/DefinitionPropertiesEdit.js
@@ -71,11 +71,15 @@ DefinitionIdEdit.prototype._setup = function(node, type) {
 
   node.setAttribute('contenteditable', true);
 
-  node.addEventListener('input', debounce(function(evt) {
-    var value = evt.target.value || evt.target.textContent;
+  var draftValue;
 
-    self.update(type, value.trim());
-  }, DEBOUNCE_DELAY));
+  node.addEventListener('focus', function(evt) {
+    draftValue = evt.target.textContent || '';
+  });
+
+  node.addEventListener('input', function(evt) {
+    draftValue = evt.target.textContent || '';
+  });
 
   node.addEventListener('keydown', function(evt) {
     if (evt.keyCode === 13) {
@@ -85,9 +89,13 @@ DefinitionIdEdit.prototype._setup = function(node, type) {
   });
 
   node.addEventListener('blur', function() {
+    var value = (draftValue || '').trim();
+
     self._clearErrorMessage();
 
-    self._definitionPropertiesView.update();
+    self.update(type, value);
+
+    draftValue = null;
   });
 };
 


### PR DESCRIPTION
### Proposed Changes

The cursor jumping while editing the definition name and ID has been a longstanding issue that has been discussed a number of times over the years. The root cause is that each input event immediately calls modeling.updateProperties

Based on the discussion in previous issues and PRs, this change addresses the problem by deferring model updates until editing has completed rather than updating the model on every keystroke.

The edited value is kept locally as a draftValue while the field has focus. During editing input events only update this local value.  When editing is complete  the final value is committed through the existing update() method.

https://github.com/user-attachments/assets/35b25790-666e-4759-8220-43618098476e




### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, Closes [274](https://github.com/bpmn-io/dmn-js/issues/274) Closes [951](https://github.com/bpmn-io/dmn-js/issues/951)
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)


