### PR TITLE
feat: add type ref dropdown

### DIFF
--- a/packages/dmn-js-drd/assets/css/dmn-js-drd.css
+++ b/packages/dmn-js-drd/assets/css/dmn-js-drd.css
@@ -93,3 +93,16 @@
 .djs-container.with-palette-two-column .dmn-definitions {
   left: 130px;
 }
+
+.djs-overlay {
+  & .dms-type-ref-dropdown {
+    display: block;
+  }
+
+  & .dms-type-ref-select {
+    background-color: var(--color-white);
+    border: 1px solid var(--input-border-color);
+    width: 125px;
+    border-radius: 12px;
+  }
+}

--- a/packages/dmn-js-drd/src/Modeler.js
+++ b/packages/dmn-js-drd/src/Modeler.js
@@ -23,6 +23,7 @@ import OutlineProvider from './features/outline';
 import PaletteModule from './features/palette';
 import ResizeModule from 'diagram-js/lib/features/resize';
 import SnappingModule from './features/snapping';
+import TypeRefDropdownModule from './features/type-ref-dropdown';
 
 /**
  * A modeler for DMN tables.
@@ -135,7 +136,8 @@ Modeler.prototype._modelingModules = [
   OutlineProvider,
   PaletteModule,
   ResizeModule,
-  SnappingModule
+  SnappingModule,
+  TypeRefDropdownModule
 ];
 
 Modeler.prototype._modules = [].concat(

--- a/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
+++ b/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
@@ -1,0 +1,136 @@
+import {
+  getBusinessObject,
+  is
+} from 'dmn-js-shared/lib/util/ModelUtil';
+
+/**
+ * Displays dropdown overlay that can be used to change element type.
+ */
+export default class TypeRefDropdown {
+
+  /**
+   *
+   * @param {import('diagram-js/lib/core/EventBus').default} eventBus
+   * @param {import('diagram-js/lib/features/overlays/Overlays').default} overlays
+   * @param {import('dmn-js-shared/lib/features/data-types/DataTypes').default} dataTypes
+   * @param {import('../modeling/DrdFactory').default} drdFactory
+   * @param {import('../modeling/Modeling').default} modeling
+   * @param {import('diagram-js/lib/i18n/translate/Translate').default} translate
+   */
+  constructor(eventBus, overlays, dataTypes, drdFactory, modeling, translate) {
+    this._eventBus = eventBus;
+    this._overlays = overlays;
+    this._dataTypes = dataTypes;
+    this._drdFactory = drdFactory;
+    this._modeling = modeling;
+    this._translate = translate;
+
+    this._eventBus.on('selection.changed', (event) => {
+
+      // clean up any existing overlays
+      this._currentTarget = null;
+      this.close();
+
+      const selection = event.newSelection;
+
+      const target = selection.length
+        ? selection.length === 1
+          ? selection[0]
+          : selection
+        : null;
+
+      if (target && is(target, 'dmn:InputData')) {
+        this._currentTarget = target;
+        this.open(target);
+      }
+    });
+  }
+
+  open(element) {
+    this._overlays.add(element, 'type-ref-dropdown', {
+      position: {
+        top: 60,
+        left: 0
+      },
+      html: this._getOverlayNode(element)
+    });
+  }
+
+  close() {
+    this._overlays.remove({ type: 'type-ref-dropdown' });
+  }
+
+  _getOverlayNode(element) {
+    const container = document.createElement('div');
+    container.className = 'dms-type-ref-dropdown';
+
+    const select = document.createElement('select');
+    select.className = 'dms-type-ref-select dms-select';
+    select.ariaLabel = this._translate('Type');
+
+    const currentTypeRef = this._getTypeRef(element);
+    const dataTypes = this._dataTypes.getAll();
+    const types = dataTypes.includes(currentTypeRef)
+      ? dataTypes
+      : [ currentTypeRef, ...dataTypes ];
+
+    const options = types.map(type => {
+      const option = document.createElement('option');
+      option.value = type;
+      option.textContent = this._translate(type);
+
+      return option;
+    });
+
+    options.forEach(option => select.appendChild(option));
+
+    select.value = currentTypeRef;
+
+    container.appendChild(select);
+
+    select.addEventListener('change', (event) => {
+      this._setTypeRef(element, event.target.value);
+    });
+
+    return container;
+  }
+
+  _getCurrentTarget() {
+    return this._currentTarget;
+  }
+
+  _getTypeRef(element) {
+    const bo = getBusinessObject(element);
+
+    return bo.get('variable')?.get('typeRef') || 'Any';
+  }
+
+  _setTypeRef(element, typeRef) {
+    const bo = getBusinessObject(element);
+    const variable = bo.get('variable');
+
+    if (!variable) {
+      const newVariable = this._drdFactory.create('dmn:InformationItem', {
+        name: bo.get('name'),
+        typeRef
+      });
+
+      this._modeling.updateProperties(element, {
+        variable: newVariable
+      });
+
+      return;
+    }
+
+    this._modeling.updateProperties(variable, { typeRef });
+  }
+}
+
+TypeRefDropdown.$inject = [
+  'eventBus',
+  'overlays',
+  'dataTypes',
+  'drdFactory',
+  'modeling',
+  'translate'
+];

--- a/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
+++ b/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
@@ -122,7 +122,7 @@ export default class TypeRefDropdown {
       return;
     }
 
-    this._modeling.updateProperties(variable, { typeRef });
+    this._modeling.updateModdleProperties(element, variable, { typeRef });
   }
 }
 

--- a/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
+++ b/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
@@ -28,19 +28,13 @@ export default class TypeRefDropdown {
     this._eventBus.on('selection.changed', (event) => {
 
       // clean up any existing overlays
-      this._currentTarget = null;
       this.close();
 
       const selection = event.newSelection;
 
-      const target = selection.length
-        ? selection.length === 1
-          ? selection[0]
-          : selection
-        : null;
+      const target = selection.length === 1 ? selection[0] : null;
 
       if (target && is(target, 'dmn:InputData')) {
-        this._currentTarget = target;
         this.open(target);
       }
     });
@@ -95,9 +89,6 @@ export default class TypeRefDropdown {
     return container;
   }
 
-  _getCurrentTarget() {
-    return this._currentTarget;
-  }
 
   _getTypeRef(element) {
     const bo = getBusinessObject(element);

--- a/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
+++ b/packages/dmn-js-drd/src/features/type-ref-dropdown/TypeRefDropdown.js
@@ -25,6 +25,8 @@ export default class TypeRefDropdown {
     this._modeling = modeling;
     this._translate = translate;
 
+    this._current = null;
+
     this._eventBus.on('selection.changed', (event) => {
 
       // clean up any existing overlays
@@ -38,20 +40,50 @@ export default class TypeRefDropdown {
         this.open(target);
       }
     });
+
+    this._eventBus.on('elements.changed', event => {
+      if (!this._current) {
+        return;
+      }
+
+      const { element } = this._current;
+
+      if (event.elements.includes(element)) {
+        this._update();
+      }
+    });
   }
 
   open(element) {
+    const container = this._getOverlayNode(element);
+    this._current = {
+      element,
+      container
+    };
+
     this._overlays.add(element, 'type-ref-dropdown', {
       position: {
         top: 60,
         left: 0
       },
-      html: this._getOverlayNode(element)
+      html: container
     });
   }
 
   close() {
+    this._current = null;
     this._overlays.remove({ type: 'type-ref-dropdown' });
+  }
+
+  _update() {
+    if (!this._current) {
+      return;
+    }
+
+    const { element, container } = this._current;
+
+    const select = container.querySelector('select');
+    select.value = this._getTypeRef(element);
   }
 
   _getOverlayNode(element) {

--- a/packages/dmn-js-drd/src/features/type-ref-dropdown/index.js
+++ b/packages/dmn-js-drd/src/features/type-ref-dropdown/index.js
@@ -1,0 +1,16 @@
+import TranslateModule from 'diagram-js/lib/i18n/translate';
+import OverlaysModule from 'diagram-js/lib/features/overlays';
+
+import DataTypesModule from 'dmn-js-shared/lib/features/data-types';
+
+import TypeRefDropdown from './TypeRefDropdown';
+
+export default {
+  __depends__: [
+    DataTypesModule,
+    OverlaysModule,
+    TranslateModule
+  ],
+  __init__: [ 'typeRefDropdown' ],
+  typeRefDropdown: [ 'type', TypeRefDropdown ]
+};

--- a/packages/dmn-js-drd/test/spec/features/type-ref-dropdown/TypeRefDropdown.dmn
+++ b/packages/dmn-js-drd/test/spec/features/type-ref-dropdown/TypeRefDropdown.dmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="typeRefDropdown" name="TypeRefDropdown" namespace="http://camunda.org/schema/1.0/dmn">
+  <inputData id="withVariable_id" name="With Variable">
+    <variable id="withVariable_ii" name="With Variable" typeRef="boolean" />
+  </inputData>
+  <inputData id="noVariable_id" name="No Variable" />
+  <inputData id="noTypeRef_id" name="No TypeRef">
+    <variable id="noTypeRef_ii" name="No TypeRef" />
+  </inputData>
+  <inputData id="unknownTypeRef_id" name="Unknown TypeRef">
+    <variable id="unknownTypeRef_ii" name="Unknown TypeRef" typeRef="integer" />
+  </inputData>
+  <decision id="someDecision_id" name="Some Decision">
+    <decisionTable id="someDecisionTable_id">
+      <output id="someDecisionOutput_id" label="" name="" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1">
+      <dmndi:DMNShape id="withVariable_id_di" dmnElementRef="withVariable_id">
+        <dc:Bounds height="45" width="125" x="150" y="250" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="noVariable_id_di" dmnElementRef="noVariable_id">
+        <dc:Bounds height="45" width="125" x="330" y="250" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="noTypeRef_id_di" dmnElementRef="noTypeRef_id">
+        <dc:Bounds height="45" width="125" x="510" y="250" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="unknownTypeRef_id_di" dmnElementRef="unknownTypeRef_id">
+        <dc:Bounds height="45" width="125" x="690" y="250" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="someDecision_id_di" dmnElementRef="someDecision_id">
+        <dc:Bounds height="80" width="180" x="150" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/type-ref-dropdown/TypeRefDropdownSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/type-ref-dropdown/TypeRefDropdownSpec.js
@@ -320,6 +320,45 @@ describe('features - type-ref-dropdown', function() {
   });
 
 
+  describe('external changes', function() {
+
+    it('should update select value on undo', inject(
+      function(elementRegistry, selection, commandStack) {
+
+        // given
+        const element = elementRegistry.get('withVariable_id');
+        selection.select(element);
+        triggerSelectChange(querySelect('withVariable_id'), 'number');
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(querySelect('withVariable_id').value).to.equal('boolean');
+      }
+    ));
+
+
+    it('should update select value on redo', inject(
+      function(elementRegistry, selection, commandStack) {
+
+        // given
+        const element = elementRegistry.get('withVariable_id');
+        selection.select(element);
+        triggerSelectChange(querySelect('withVariable_id'), 'number');
+        commandStack.undo();
+
+        // when
+        commandStack.redo();
+
+        // then
+        expect(querySelect('withVariable_id').value).to.equal('number');
+      }
+    ));
+
+  });
+
+
   // helpers //////////////
 
   function queryOverlay(elementId) {

--- a/packages/dmn-js-drd/test/spec/features/type-ref-dropdown/TypeRefDropdownSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/type-ref-dropdown/TypeRefDropdownSpec.js
@@ -1,0 +1,340 @@
+import { expect } from 'chai';
+
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import TestContainer from 'mocha-test-container-support';
+
+import { query as domQuery, queryAll as domQueryAll } from 'min-dom';
+
+import { getBusinessObject } from 'dmn-js-shared/lib/util/ModelUtil';
+
+import coreModule from 'src/core';
+import modelingModule from 'src/features/modeling';
+import typeRefDropdownModule from 'src/features/type-ref-dropdown';
+
+const diagramXML = require('./TypeRefDropdown.dmn');
+
+
+describe('features - type-ref-dropdown', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  const testModules = [
+    coreModule,
+    modelingModule,
+    typeRefDropdownModule
+  ];
+
+  beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+  describe('overlay', function() {
+
+    describe('open', function() {
+
+      it('should show overlay when InputData is selected', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('withVariable_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          expect(queryOverlay('withVariable_id')).to.exist;
+        }
+      ));
+
+
+      it('should NOT show overlay when non-InputData is selected', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('someDecision_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          expect(queryOverlay('someDecision_id')).to.be.null;
+        }
+      ));
+
+
+      it('should close overlay when selection is cleared', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('withVariable_id');
+          selection.select(element);
+
+          // when
+          selection.select([]);
+
+          // then
+          expect(queryOverlay('withVariable_id')).to.be.null;
+        }
+      ));
+
+
+      it('should close and reopen when selection switches to another InputData', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const first = elementRegistry.get('withVariable_id');
+          const second = elementRegistry.get('noVariable_id');
+
+          selection.select(first);
+
+          // when
+          selection.select(second);
+
+          // then
+          expect(queryOverlay('withVariable_id')).to.be.null;
+          expect(queryOverlay('noVariable_id')).to.exist;
+        }
+      ));
+
+
+      it('should NOT show overlay for multi-selection', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const first = elementRegistry.get('withVariable_id');
+          const second = elementRegistry.get('noVariable_id');
+
+          // when
+          selection.select([ first, second ]);
+
+          // then
+          expect(queryOverlay('withVariable_id')).to.be.null;
+          expect(queryOverlay('noVariable_id')).to.be.null;
+        }
+      ));
+
+    });
+
+
+    describe('content', function() {
+
+      it('should populate options from all data types', inject(
+        function(elementRegistry, selection, dataTypes) {
+
+          // given
+          const element = elementRegistry.get('withVariable_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          const selectEl = querySelect('withVariable_id');
+          expect(domQueryAll('option', selectEl)).to.have.length(dataTypes.getAll().length);
+        }
+      ));
+
+
+      it('should pre-select the current typeRef', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('withVariable_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          const selectEl = querySelect('withVariable_id');
+          expect(selectEl.value).to.equal('boolean');
+        }
+      ));
+
+
+      it('should pre-select "Any" when no variable exists', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('noVariable_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          const selectEl = querySelect('noVariable_id');
+          expect(selectEl.value).to.equal('Any');
+        }
+      ));
+
+
+      it('should show value when variable typeRef is not in data types', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('unknownTypeRef_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          const selectEl = querySelect('unknownTypeRef_id');
+          expect(selectEl.value).to.equal('integer');
+        }
+      ));
+
+
+      it('should pre-select "Any" when variable has no typeRef', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('noTypeRef_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          const selectEl = querySelect('noTypeRef_id');
+          expect(selectEl.value).to.equal('Any');
+        }
+      ));
+
+
+      it('should have accessible aria-label', inject(
+        function(elementRegistry, selection) {
+
+          // given
+          const element = elementRegistry.get('withVariable_id');
+
+          // when
+          selection.select(element);
+
+          // then
+          const selectEl = querySelect('withVariable_id');
+          expect(selectEl.ariaLabel).to.equal('Type');
+        }
+      ));
+
+    });
+
+  });
+
+
+  describe('setTypeRef', function() {
+
+    it('should update typeRef when variable exists', inject(
+      function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('withVariable_id');
+        const bo = getBusinessObject(element);
+        selection.select(element);
+
+        // when
+        triggerSelectChange(querySelect('withVariable_id'), 'number');
+
+        // then
+        expect(bo.variable.typeRef).to.equal('number');
+      }
+    ));
+
+
+    it('should create new variable when none exists', inject(
+      function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('noVariable_id');
+        const bo = getBusinessObject(element);
+        selection.select(element);
+
+        // when
+        triggerSelectChange(querySelect('noVariable_id'), 'string');
+
+        // then
+        expect(bo.variable).to.exist;
+        expect(bo.variable.typeRef).to.equal('string');
+        expect(bo.variable.name).to.equal(bo.get('name'));
+      }
+    ));
+
+
+    it('should undo typeRef update', inject(
+      function(elementRegistry, selection, commandStack) {
+
+        // given
+        const element = elementRegistry.get('withVariable_id');
+        const bo = getBusinessObject(element);
+        selection.select(element);
+        triggerSelectChange(querySelect('withVariable_id'), 'number');
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(bo.variable.typeRef).to.equal('boolean');
+      }
+    ));
+
+
+    it('should redo typeRef update', inject(
+      function(elementRegistry, selection, commandStack) {
+
+        // given
+        const element = elementRegistry.get('withVariable_id');
+        const bo = getBusinessObject(element);
+        selection.select(element);
+        triggerSelectChange(querySelect('withVariable_id'), 'number');
+        commandStack.undo();
+
+        // when
+        commandStack.redo();
+
+        // then
+        expect(bo.variable.typeRef).to.equal('number');
+      }
+    ));
+
+
+    it('should undo variable creation', inject(
+      function(elementRegistry, selection, commandStack) {
+
+        // given
+        const element = elementRegistry.get('noVariable_id');
+        const bo = getBusinessObject(element);
+        selection.select(element);
+        triggerSelectChange(querySelect('noVariable_id'), 'string');
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(bo.variable).not.to.exist;
+      }
+    ));
+
+  });
+
+
+  // helpers //////////////
+
+  function queryOverlay(elementId) {
+    const containerEl = domQuery('[data-container-id="' + elementId + '"]', container);
+    return containerEl && domQuery('.dms-type-ref-dropdown', containerEl);
+  }
+
+  function querySelect(elementId) {
+    const overlay = queryOverlay(elementId);
+    return overlay && domQuery('select', overlay);
+  }
+
+  function triggerSelectChange(selectEl, value) {
+    selectEl.value = value;
+    selectEl.dispatchEvent(new Event('change'));
+  }
+
+});


### PR DESCRIPTION
### Proposed Changes

This PR adds a dropdown which allows to set the type of input data. It uses the `dataTypes` service to provide the options.

<img width="203" height="135" alt="image" src="https://github.com/user-attachments/assets/2ff84a2a-59ca-47a7-986a-07cd13d958c0" />

This will collide with [improved-canvas](https://github.com/camunda/improved-canvas), and I will provide an adjustment as a follow-up.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
