### PR TITLE
feat(drd): create variable for decision and input data per default

### DIFF
--- a/packages/dmn-js-drd/src/features/modeling/behavior/CreateShapeBehavior.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/CreateShapeBehavior.js
@@ -1,0 +1,46 @@
+import inherits from 'inherits-browser';
+
+import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
+
+import { is } from 'dmn-js-shared/lib/util/ModelUtil';
+
+
+/**
+ * Assigns a default variable to newly created Decisions and Input Data.
+ */
+export default function CreateShapeBehavior(drdFactory, injector) {
+  injector.invoke(CommandInterceptor, this);
+
+  this.preExecute('shape.create', function(context) {
+    var shape = context.shape,
+        hints = context.hints || {},
+        businessObject = shape.businessObject;
+
+    if (hints.createElementsBehavior === false) {
+      return;
+    }
+
+    if (businessObject.variable) {
+      return;
+    }
+
+    if (!(is(shape, 'dmn:Decision') || is(shape, 'dmn:InputData'))) {
+      return;
+    }
+
+    var variable = drdFactory.create('dmn:InformationItem', {
+      name: businessObject.name,
+      typeRef: 'Any'
+    });
+
+    variable.$parent = businessObject;
+    businessObject.variable = variable;
+  }, true);
+}
+
+CreateShapeBehavior.$inject = [
+  'drdFactory',
+  'injector'
+];
+
+inherits(CreateShapeBehavior, CommandInterceptor);

--- a/packages/dmn-js-drd/src/features/modeling/behavior/index.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/index.js
@@ -1,4 +1,5 @@
 import CreateConnectionBehavior from './CreateConnectionBehavior';
+import CreateShapeBehavior from './CreateShapeBehavior';
 import LayoutConnectionBehavior from './LayoutConnectionBehavior';
 import ReplaceConnectionBehavior from './ReplaceConnectionBehavior';
 import ReplaceElementBehavior from './ReplaceElementBehavior';
@@ -9,6 +10,7 @@ import NameChangeBehavior from
 export default {
   __init__: [
     'createConnectionBehavior',
+    'createShapeBehavior',
     'idChangeBehavior',
     'nameChangeBehavior',
     'layoutConnectionBehavior',
@@ -16,6 +18,7 @@ export default {
     'replaceElementBehavior'
   ],
   createConnectionBehavior: [ 'type', CreateConnectionBehavior ],
+  createShapeBehavior: [ 'type', CreateShapeBehavior ],
   idChangeBehavior: [ 'type', IdChangeBehavior ],
   nameChangeBehavior: [ 'type', NameChangeBehavior ],
   layoutConnectionBehavior: [ 'type', LayoutConnectionBehavior ],

--- a/packages/dmn-js-drd/src/features/replace/DrdReplace.js
+++ b/packages/dmn-js-drd/src/features/replace/DrdReplace.js
@@ -34,6 +34,14 @@ export default function DrdReplace(drdFactory, replace, selection, modeling) {
 
     newBusinessObject.name = oldBusinessObject.name;
 
+    // keep the existing variable (and its type ref) across the morph
+    var variable = oldBusinessObject.variable;
+
+    if (variable) {
+      newBusinessObject.variable = variable;
+      variable.$parent = newBusinessObject;
+    }
+
     if (target.table) {
       var table = drdFactory.create('dmn:DecisionTable');
       table.$parent = newBusinessObject;
@@ -59,13 +67,9 @@ export default function DrdReplace(drdFactory, replace, selection, modeling) {
     }
 
     if (target.expression) {
+      var literalExpression = drdFactory.create('dmn:LiteralExpression');
 
-      // variable set to element name
-      var literalExpression = drdFactory.create('dmn:LiteralExpression'),
-          variable = drdFactory.create('dmn:InformationItem',
-            { name: oldBusinessObject.name });
-
-      setBoxedExpression(newBusinessObject, literalExpression, drdFactory, variable);
+      setBoxedExpression(newBusinessObject, literalExpression, drdFactory);
     }
 
     return replace.replaceElement(element, newElement, hints);
@@ -82,7 +86,7 @@ DrdReplace.$inject = [
 ];
 
 // helper //////////////////////////////////////////////////////////////
-function setBoxedExpression(bo, expression, drdFactory, variable) {
+function setBoxedExpression(bo, expression, drdFactory) {
   if (is(bo, 'dmn:Decision')) {
     bo.decisionLogic = expression;
     expression.$parent = bo;
@@ -93,10 +97,5 @@ function setBoxedExpression(bo, expression, drdFactory, variable) {
     bo.encapsulatedLogic = encapsulatedLogic;
     encapsulatedLogic.$parent = bo;
     expression.$parent = encapsulatedLogic;
-  }
-
-  if (variable) {
-    bo.variable = variable;
-    variable.$parent = bo;
   }
 }

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/CreateShapeBehaviorSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/CreateShapeBehaviorSpec.js
@@ -1,0 +1,120 @@
+import { expect } from 'chai';
+import {
+  bootstrapModeler,
+  inject
+} from '../../../../TestHelper';
+
+import coreModule from 'src/core';
+import modelingModule from 'src/features/modeling';
+
+
+describe('features/modeling - CreateShapeBehavior', function() {
+
+  var testModules = [ coreModule, modelingModule ];
+
+  var diagramXML = require('./create-shape-behavior.dmn');
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: testModules
+  }));
+
+
+  it('should create a default variable for a new decision', inject(
+    function(canvas, elementFactory, modeling) {
+
+      // given
+      var rootElement = canvas.getRootElement();
+
+      // when
+      var decision = elementFactory.createShape({ type: 'dmn:Decision' });
+      modeling.createShape(decision, { x: 100, y: 100 }, rootElement);
+
+      // then
+      var variable = decision.businessObject.variable;
+
+      expect(variable).to.exist;
+      expect(variable.typeRef).to.equal('Any');
+      expect(variable.$parent).to.equal(decision.businessObject);
+    }
+  ));
+
+
+  it('should create a default variable for a new input data', inject(
+    function(canvas, elementFactory, modeling) {
+
+      // given
+      var rootElement = canvas.getRootElement();
+
+      // when
+      var inputData = elementFactory.createShape({ type: 'dmn:InputData' });
+      modeling.createShape(inputData, { x: 100, y: 100 }, rootElement);
+
+      // then
+      var variable = inputData.businessObject.variable;
+
+      expect(variable).to.exist;
+      expect(variable.typeRef).to.equal('Any');
+      expect(variable.$parent).to.equal(inputData.businessObject);
+    }
+  ));
+
+
+  it('should not create a variable for other shapes', inject(
+    function(canvas, elementFactory, modeling) {
+
+      // given
+      var rootElement = canvas.getRootElement();
+
+      // when
+      var knowledgeSource = elementFactory.createShape({ type: 'dmn:KnowledgeSource' });
+      modeling.createShape(knowledgeSource, { x: 100, y: 100 }, rootElement);
+
+      // then
+      expect(knowledgeSource.businessObject.variable).not.to.exist;
+    }
+  ));
+
+
+  it('should not overwrite an existing variable', inject(
+    function(canvas, drdFactory, elementFactory, modeling) {
+
+      // given
+      var rootElement = canvas.getRootElement(),
+          businessObject = drdFactory.create('dmn:Decision', { name: 'Season' }),
+          variable = drdFactory.create('dmn:InformationItem', { name: 'Season' });
+
+      variable.$parent = businessObject;
+      businessObject.variable = variable;
+
+      // when
+      var decision = elementFactory.createShape({
+        type: 'dmn:Decision',
+        businessObject: businessObject
+      });
+      modeling.createShape(decision, { x: 100, y: 100 }, rootElement);
+
+      // then
+      expect(decision.businessObject.variable).to.equal(variable);
+      expect(decision.businessObject.variable.typeRef).not.to.exist;
+    }
+  ));
+
+
+  it('should not create a variable when createElementsBehavior hint is false', inject(
+    function(canvas, elementFactory, modeling) {
+
+      // given
+      var rootElement = canvas.getRootElement();
+
+      // when
+      var decision = elementFactory.createShape({ type: 'dmn:Decision' });
+      modeling.createShape(decision, { x: 100, y: 100 }, rootElement, {
+        createElementsBehavior: false
+      });
+
+      // then
+      expect(decision.businessObject.variable).not.to.exist;
+    }
+  ));
+
+});

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/create-shape-behavior.dmn
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/create-shape-behavior.dmn
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" id="drd-id" name="drd-name" namespace="http://camunda.org/schema/1.0/dmn">
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="Diagram_1" />
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/replace/DrdReplaceSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/replace/DrdReplaceSpec.js
@@ -90,6 +90,62 @@ describe('features/replace - drd replace', function() {
     }));
 
 
+    it('should keep existing variable when replacing with literal expression', inject(
+      function(elementRegistry, drdReplace, drdFactory, modeling) {
+
+        // given
+        var decision = elementRegistry.get('decision'),
+            variable = drdFactory.create('dmn:InformationItem', {
+              name: decision.businessObject.name,
+              typeRef: 'boolean'
+            });
+
+        modeling.updateProperties(decision, { variable: variable });
+
+        var newElementData = {
+          type: 'dmn:Decision',
+          table: false,
+          expression: true
+        };
+
+        // when
+        var newElement = drdReplace.replaceElement(decision, newElementData);
+
+        // then
+        expect(newElement.businessObject.variable).to.equal(variable);
+        expect(newElement.businessObject.variable.typeRef).to.equal('boolean');
+      }
+    ));
+
+
+    it('should keep existing variable when replacing with decision table', inject(
+      function(elementRegistry, drdReplace, drdFactory, modeling) {
+
+        // given
+        var decision = elementRegistry.get('decision'),
+            variable = drdFactory.create('dmn:InformationItem', {
+              name: decision.businessObject.name,
+              typeRef: 'boolean'
+            });
+
+        modeling.updateProperties(decision, { variable: variable });
+
+        var newElementData = {
+          type: 'dmn:Decision',
+          table: true,
+          expression: false
+        };
+
+        // when
+        var newElement = drdReplace.replaceElement(decision, newElementData);
+
+        // then
+        expect(newElement.businessObject.variable).to.equal(variable);
+        expect(newElement.businessObject.variable.typeRef).to.equal('boolean');
+      }
+    ));
+
+
     it('nothing', inject(function(elementRegistry, drdReplace) {
 
       // given

--- a/packages/dmn-js/test/spec/ModelerSpec.js
+++ b/packages/dmn-js/test/spec/ModelerSpec.js
@@ -54,6 +54,12 @@ describe('Modeler', function() {
     editor = new Modeler({
       container: container,
     });
+
+    if (singleStart) {
+      editor.on('viewer.created', ({ viewer }) => viewer.on('elements.changed', function() {
+        editor.saveXML({ format: true }).then(({ xml }) => console.log(xml)).catch(console.error);
+      }));
+    }
   });
 
   if (!singleStart) {


### PR DESCRIPTION
### Proposed Changes

This PR changes the editor behavior to always create a variable element for newly added decisions and input data. In case a decision's implementation changes, the variable is preserved. The change enables usage of the editor for a strictly typed engine (jDMN).

https://github.com/user-attachments/assets/9f522686-ebb7-42c2-995f-fe67e407cc3c


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
