### PR TITLE
fix(drd): prevent clipped strokes in exported diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6442,47 +6442,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/execa": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.0.tgz",
-      "integrity": "sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.1",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "path-key": "^4.0.0",
-        "pretty-ms": "^9.3.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "which-command": "^0.1.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -12491,22 +12450,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-command": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
-      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "which-command": "cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
-      }
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -12781,7 +12724,7 @@
         "del-cli": "^7.0.0",
         "diagram-js": "^15.21.0",
         "dmn-font": "^0.6.2",
-        "execa": "^10.0.0",
+        "execa": "^9.6.1",
         "min-dom": "^5.3.0",
         "rollup": "^4.62.2",
         "rollup-plugin-license": "^3.7.1"
@@ -12883,6 +12826,33 @@
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
         "inferno-test-utils": "~5.6.2"
+      }
+    },
+    "packages/dmn-js/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,16 +5426,16 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.21.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.21.0.tgz",
-      "integrity": "sha512-i+rRzHxdvlXOu9klcZyvKIl2cRv9TwdzoDmpQvl01+5LEgsNnbanQQEg6WRpR0aCNxJ3jion/eOJ6L7R9XaqLA==",
+      "version": "15.23.2",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.2.tgz",
+      "integrity": "sha512-J/CSCKSq62z7aYr643sf+IBiBv3oaJVJc0PivNi09Wdnd/aUOGpIl8PC0HrJn8sLC/lVNtd80MyscbSg2xDZmA==",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.4",
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "object-refs": "^0.4.0",
         "path-intersection": "^4.1.0",
@@ -6443,66 +6443,41 @@
       }
     },
     "node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.0.tgz",
+      "integrity": "sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
         "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
+        "get-stream": "^9.0.1",
         "human-signals": "^8.0.1",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
         "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
+        "path-key": "^4.0.0",
+        "pretty-ms": "^9.3.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.5.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/execa/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/execa/node_modules/is-unicode-supported": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6600,6 +6575,35 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -7830,6 +7834,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -8853,9 +8870,9 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "license": "MIT"
     },
     "node_modules/min-dom": {
@@ -12474,6 +12491,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -12748,7 +12781,7 @@
         "del-cli": "^7.0.0",
         "diagram-js": "^15.21.0",
         "dmn-font": "^0.6.2",
-        "execa": "^9.6.1",
+        "execa": "^10.0.0",
         "min-dom": "^5.3.0",
         "rollup": "^4.62.2",
         "rollup-plugin-license": "^3.7.1"
@@ -12797,7 +12830,7 @@
       "version": "17.10.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "diagram-js": "^15.21.0",
+        "diagram-js": "^15.23.2",
         "diagram-js-direct-editing": "^3.4.0",
         "dmn-js-shared": "^17.10.0",
         "ids": "^3.0.2",

--- a/packages/dmn-js-drd/package.json
+++ b/packages/dmn-js-drd/package.json
@@ -29,7 +29,7 @@
     "drd"
   ],
   "dependencies": {
-    "diagram-js": "^15.21.0",
+    "diagram-js": "^15.23.2",
     "diagram-js-direct-editing": "^3.4.0",
     "dmn-js-shared": "^17.10.0",
     "ids": "^3.0.2",

--- a/packages/dmn-js-drd/src/Viewer.js
+++ b/packages/dmn-js-drd/src/Viewer.js
@@ -7,6 +7,7 @@
 
 import {
   domify,
+  classes as domClasses,
   query as domQuery,
   remove as domRemove
 } from 'min-dom';
@@ -31,6 +32,23 @@ import {
   addProjectLogo
 } from 'dmn-js-shared/lib/util/PoweredByUtil';
 
+
+/**
+ * Padding added around the diagram bounds on SVG export.
+ *
+ * `getBBox` returns the geometry bounds only, excluding element strokes, so
+ * without padding strokes at the diagram edges get clipped. Historically this
+ * padding was provided implicitly by element outlines, which diagram-js now
+ * creates lazily (diagram-js@15.19, bpmn-io/diagram-js#1064).
+ */
+const EXPORT_PADDING = 5;
+
+/**
+ * Class set on the canvas container to hide element outlines, which diagram-js
+ * excludes from rendering while present. Applied when measuring the export
+ * bounds so lazily created outlines do not skew them.
+ */
+const OUTLINE_HIDDEN_CLS = 'djs-outline-hidden';
 
 /**
  * @typedef {import('dmn-js-shared/lib/base/View).OpenResult} OpenResult
@@ -132,15 +150,31 @@ Viewer.prototype.saveSVG = wrapForCompatibility(function(options) {
     var contents = innerSVG(contentNode),
         defs = (defsNode && defsNode.outerHTML) || '';
 
-    var bbox = contentNode.getBBox();
+    // hide outlines so they do not skew the measured bounds
+    var container = canvas.getContainer();
+
+    domClasses(container).add(OUTLINE_HIDDEN_CLS);
+
+    var bbox;
+
+    try {
+      bbox = contentNode.getBBox();
+    } finally {
+      domClasses(container).remove(OUTLINE_HIDDEN_CLS);
+    }
+
+    var x = bbox.x - EXPORT_PADDING,
+        y = bbox.y - EXPORT_PADDING,
+        width = bbox.width + EXPORT_PADDING * 2,
+        height = bbox.height + EXPORT_PADDING * 2;
 
     var svg =
       '<?xml version="1.0" encoding="utf-8"?>\n' +
       '<!-- created with dmn-js / http://bpmn.io -->\n' +
       '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +
       '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' +
-           'width="' + bbox.width + '" height="' + bbox.height + '" ' +
-           'viewBox="' + bbox.x + ' ' + bbox.y + ' ' + bbox.width + ' ' + bbox.height + '" version="1.1">' +
+           'width="' + width + '" height="' + height + '" ' +
+           'viewBox="' + x + ' ' + y + ' ' + width + ' ' + height + '" version="1.1">' +
         defs + contents +
       '</svg>';
 

--- a/packages/dmn-js-drd/test/spec/ViewerSpec.js
+++ b/packages/dmn-js-drd/test/spec/ViewerSpec.js
@@ -118,6 +118,13 @@ describe('Viewer', function() {
 
   describe('export', function() {
 
+    function getViewBox(svg) {
+      return new DOMParser()
+        .parseFromString(svg, 'image/svg+xml')
+        .querySelector('svg')
+        .getAttribute('viewBox');
+    }
+
     function expectValidSVG(svg) {
       const expectedStart = '<?xml version="1.0" encoding="utf-8"?>';
       const expectedEnd = '</svg>';
@@ -153,6 +160,61 @@ describe('Viewer', function() {
 
       // then
       expectValidSVG(svg);
+    });
+
+
+    it('should pad viewport to not clip strokes at diagram bounds', async function() {
+
+      // given
+      await createViewer(exampleXML);
+
+      const drdViewer = viewer.getActiveViewer();
+
+      const bbox = drdViewer.get('canvas').getActiveLayer().getBBox();
+
+      // when
+      const { svg } = await drdViewer.saveSVG();
+
+      // then
+      const svgNode = new DOMParser().parseFromString(svg, 'image/svg+xml').querySelector('svg');
+
+      expect(svgNode.getAttribute('width')).to.eql(String(bbox.width + 10));
+      expect(svgNode.getAttribute('height')).to.eql(String(bbox.height + 10));
+      expect(svgNode.getAttribute('viewBox')).to.eql(
+        [ bbox.x - 5, bbox.y - 5, bbox.width + 10, bbox.height + 10 ].join(' ')
+      );
+    });
+
+
+    it('should ignore outlines when computing export bounds', async function() {
+
+      // given
+      await createViewer(exampleXML);
+
+      const drdViewer = viewer.getActiveViewer();
+
+      const { svg: withoutOutline } = await drdViewer.saveSVG();
+
+      const elementRegistry = drdViewer.get('elementRegistry');
+
+      const element = elementRegistry.get('dish-decision'),
+            gfx = elementRegistry.getGraphics(element);
+
+      const outline = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+
+      outline.setAttribute('class', 'djs-outline');
+      outline.setAttribute('x', -1000);
+      outline.setAttribute('y', -1000);
+      outline.setAttribute('width', element.width + 2000);
+      outline.setAttribute('height', element.height + 2000);
+
+      gfx.appendChild(outline);
+
+      // when
+      const { svg: withOutline } = await drdViewer.saveSVG();
+
+      // then
+      expect(getViewBox(withOutline)).to.eql(getViewBox(withoutOutline));
     });
 
   });


### PR DESCRIPTION
### Proposed Changes

<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

Bump diagram-js and hide element outlines during image export.

Related to https://github.com/camunda/camunda-modeler/issues/6065

### Checklist

Ensure you provide everything we need to review your contribution:

* [ ] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [ ] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
