### PR TITLE
fix(literal-expression): open decisions without variable element

### DIFF
--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesComponent.js
@@ -10,10 +10,10 @@ export default class LiteralExpressionPropertiesComponent extends Component {
   }
 
   render() {
-    const {
-      decisionLogic: literalExpression,
-      variable
-    } = this._viewer.getDecision();
+    const decision = this._viewer.getDecision();
+
+    const literalExpression = decision.get('decisionLogic');
+    const variable = decision.get('variable');
 
     return (
       <div className="literal-expression-properties">
@@ -21,13 +21,13 @@ export default class LiteralExpressionPropertiesComponent extends Component {
           <tr>
             <td>{ this._translate('Variable name:') }</td>
             <td>
-              <span>{ variable.name || '-' }</span>
+              <span>{ (variable && variable.get('name')) || '-' }</span>
             </td>
           </tr>
           <tr>
             <td>{ this._translate('Variable type:') }</td>
             <td>
-              <span>{ this._translate(variable.typeRef || '') || '-' }</span>
+              <span>{ this._translate((variable && variable.get('typeRef')) || '') || '-' }</span>
 
             </td>
           </tr>

--- a/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
+++ b/packages/dmn-js-literal-expression/src/features/literal-expression-properties/components/LiteralExpressionPropertiesEditorComponent.js
@@ -14,10 +14,11 @@ export default class LiteralExpressionPropertiesComponent extends Component {
     this._dataTypes = context.injector.get('dataTypes');
     this._eventBus = context.injector.get('eventBus');
     const decision = this._viewer.getDecision();
+    const variable = decision.get('variable');
 
     this.state = {
-      name: decision.variable.name,
-      typeRef: decision.variable.typeRef
+      name: variable && variable.get('name'),
+      typeRef: variable && variable.get('typeRef')
     };
 
     this.setVariableName = this.setVariableName.bind(this);
@@ -42,9 +43,11 @@ export default class LiteralExpressionPropertiesComponent extends Component {
 
   onChange = () => {
     const decision = this._viewer.getDecision();
-    if (decision.variable) {
+    const variable = decision.get('variable');
+
+    if (variable) {
       this.setState({
-        name: decision.variable.name
+        name: variable.get('name')
       });
     }
   };

--- a/packages/dmn-js-literal-expression/src/features/modeling/Modeling.js
+++ b/packages/dmn-js-literal-expression/src/features/modeling/Modeling.js
@@ -8,10 +8,11 @@ import UpdatePropertiesHandler
 
 export default class Modeling {
 
-  constructor(commandStack, viewer, eventBus) {
+  constructor(commandStack, viewer, eventBus, moddle) {
     this._commandStack = commandStack;
     this._viewer = viewer;
     this._eventBus = eventBus;
+    this._moddle = moddle;
 
     eventBus.on('viewer.init', () => {
 
@@ -89,8 +90,14 @@ export default class Modeling {
   }
 
   editVariableName(name) {
-    const decision = this.getDecision(),
-          variable = decision.variable;
+    const decision = this.getDecision();
+    const variable = decision.get('variable');
+
+    if (!variable) {
+      this._createVariable(decision, { name });
+
+      return;
+    }
 
     const context = {
       element: variable,
@@ -103,8 +110,14 @@ export default class Modeling {
   }
 
   editVariableType(typeRef) {
-    const decision = this.getDecision(),
-          variable = decision.variable;
+    const decision = this.getDecision();
+    const variable = decision.get('variable');
+
+    if (!variable) {
+      this._createVariable(decision, { typeRef });
+
+      return;
+    }
 
     const context = {
       element: variable,
@@ -114,6 +127,18 @@ export default class Modeling {
     };
 
     this._commandStack.execute('element.updateProperties', context);
+  }
+
+  _createVariable(decision, properties) {
+    const variable = this._moddle.create('dmn:InformationItem', {
+      name: decision.get('name'),
+      ...properties
+    });
+
+    variable.set('id', this._moddle.ids.nextPrefixed('InformationItem_', variable));
+    variable.$parent = decision;
+
+    this.updateProperties(decision, { variable });
   }
 
   updateProperties(el, props) {
@@ -126,7 +151,7 @@ export default class Modeling {
   }
 }
 
-Modeling.$inject = [ 'commandStack', 'viewer', 'eventBus' ];
+Modeling.$inject = [ 'commandStack', 'viewer', 'eventBus', 'moddle' ];
 
 
 // helpers //////////////////////

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorProperties.no-variable.dmn
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorProperties.no-variable.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="Definitions_1urqfvl" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="dev" camunda:diagramRelationId="6d44610f-09df-44e2-a801-e7b15e2460ce" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <decision id="Decision_03j2fif" name="Decision 1">
+    <literalExpression id="LiteralExpression_1yv48vf" />
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape id="DMNShape_0jeimi8" dmnElementRef="Decision_03j2fif">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionEditorPropertiesSpec.js
@@ -19,6 +19,8 @@ import literalExpressionXML from '../../literal-expression.dmn';
 import nonDefaultExpressionLanguageXML from '../../expression-language.dmn';
 import literalExpressionNoTypeRefXML
   from './LiteralExpressionEditorProperties.no-type-ref.dmn';
+import literalExpressionNoVariableXML
+  from './LiteralExpressionEditorProperties.no-variable.dmn';
 
 import LiteralExpressionPropertiesEditorModule
   from 'src/features/literal-expression-properties/editor';
@@ -249,6 +251,49 @@ describe('literal expression properties editor', function() {
       // then
       expect(domQuery('.literal-expression-properties', testContainer)).to.exist;
     });
+
+  });
+
+
+  describe('no variable', function() {
+
+    beforeEach(bootstrapModeler(literalExpressionNoVariableXML, {
+      modules: testModules,
+      debounceInput: false
+    }));
+
+
+    it('should render', function() {
+
+      // then
+      expect(domQuery('.literal-expression-properties', testContainer)).to.exist;
+    });
+
+
+    it('should create variable when editing name', inject(function(viewer) {
+
+      // given
+      const input = domQuery('.variable-name-input', testContainer);
+
+      // when
+      triggerInputEvent(input, 'foo');
+
+      // then
+      expect(viewer.getDecision().variable.name).to.equal('foo');
+    }));
+
+
+    it('should create variable when editing type', inject(function(viewer) {
+
+      // given
+      const inputSelect = domQuery('.variable-type-select', testContainer);
+
+      // when
+      triggerInputSelectChange(inputSelect, 'boolean', testContainer);
+
+      // then
+      expect(viewer.getDecision().variable.typeRef).to.equal('boolean');
+    }));
 
   });
 

--- a/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionPropertiesSpec.js
+++ b/packages/dmn-js-literal-expression/test/spec/features/literal-expression-properties/LiteralExpressionPropertiesSpec.js
@@ -8,6 +8,8 @@ import TestContainer from 'mocha-test-container-support';
 import literalExpressionXML from '../../literal-expression.dmn';
 import literalExpressionNoTypeRefXML
   from './LiteralExpressionEditorProperties.no-type-ref.dmn';
+import literalExpressionNoVariableXML
+  from './LiteralExpressionEditorProperties.no-variable.dmn';
 
 import CoreModule from 'src/core';
 import LiteralExpressionPropertiesModule
@@ -45,6 +47,32 @@ describe('literal expression properties', function() {
   describe('no typeRef', function() {
 
     beforeEach(bootstrapViewer(literalExpressionNoTypeRefXML, {
+      modules: [
+        CoreModule,
+        TranslateModule,
+        LiteralExpressionPropertiesModule
+      ]
+    }));
+
+    let testContainer;
+
+    beforeEach(function() {
+      testContainer = TestContainer.get(this);
+    });
+
+
+    it('should render', function() {
+
+      // then
+      expect(domQuery('.literal-expression-properties', testContainer)).to.exist;
+    });
+
+  });
+
+
+  describe('no variable', function() {
+
+    beforeEach(bootstrapViewer(literalExpressionNoVariableXML, {
       modules: [
         CoreModule,
         TranslateModule,


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/6136

### Proposed Changes

<img width="797" height="610" alt="image" src="https://github.com/user-attachments/assets/da5c4096-cd43-4bac-bc65-f47f99c6064c" />

This PR makes sure that the removal of `variable` element downstream (https://github.com/camunda/camunda-dmn-js/pull/176) is not breaking the literal expression editor. It does not assume that `variable` is always present anymore.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
