### PR TITLE
feat(drd): add decision service support for DMN 1.5

### DIFF
--- a/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
+++ b/.github/workflows/MERGE_MAIN_TO_DEVELOP.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Notify failure on Slack
       if: failure()
-      uses: slackapi/slack-github-action@v3
+      uses: slackapi/slack-github-action@v4
       with:
         method: chat.postMessage
         token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: 'fp/open-source/os-ci'
+    file:
+      - '.gitlab-ci.yml'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,0 @@
-include:
-  - project: 'fp/open-source/os-ci'
-    file:
-      - '.gitlab-ci.yml'

--- a/.gs-project.yml
+++ b/.gs-project.yml
@@ -1,1 +1,0 @@
-productGuid: "product::966543"

--- a/.gs-project.yml
+++ b/.gs-project.yml
@@ -1,0 +1,1 @@
+productGuid: "product::966543"

--- a/packages/dmn-js-drd/assets/css/dmn-js-drd.css
+++ b/packages/dmn-js-drd/assets/css/dmn-js-drd.css
@@ -94,6 +94,18 @@
   left: 130px;
 }
 
+.dmn-icon-decision-service::before {
+  content: '';
+  display: inline-block;
+  width: 32px;
+  height: 24px;
+  background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="6" width="28" height="18" rx="3" stroke="black" stroke-width="1.5" fill="none"/><line x1="1" y1="15" x2="29" y2="15" stroke="black" stroke-width="1.5" stroke-linecap="butt"/></svg>');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  vertical-align: middle;
+}
+
 .djs-overlay {
   & .dms-type-ref-dropdown {
     display: block;

--- a/packages/dmn-js-drd/assets/css/dmn-js-drd.css
+++ b/packages/dmn-js-drd/assets/css/dmn-js-drd.css
@@ -97,12 +97,17 @@
 .dmn-icon-decision-service::before {
   content: '';
   display: inline-block;
-  width: 32px;
-  height: 24px;
-  background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="6" width="28" height="18" rx="3" stroke="black" stroke-width="1.5" fill="none"/><line x1="1" y1="15" x2="29" y2="15" stroke="black" stroke-width="1.5" stroke-linecap="butt"/></svg>');
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
+  width: 1em;
+  height: 1em;
+  background-color: currentColor;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="6" width="28" height="18" rx="3" stroke="black" stroke-width="1.5" fill="none"/><line x1="1" y1="15" x2="29" y2="15" stroke="black" stroke-width="1.5" stroke-linecap="butt"/></svg>');
+  mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="6" width="28" height="18" rx="3" stroke="black" stroke-width="1.5" fill="none"/><line x1="1" y1="15" x2="29" y2="15" stroke="black" stroke-width="1.5" stroke-linecap="butt"/></svg>');
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
   vertical-align: middle;
 }
 

--- a/packages/dmn-js-drd/assets/css/dmn-js-drd.css
+++ b/packages/dmn-js-drd/assets/css/dmn-js-drd.css
@@ -32,7 +32,7 @@
   border: none;
   border-radius: 1px;
   background: var(--drill-down-overlay-background-color);
-  color: var(--drill-down-overlay-color);
+  color: var(--drill-down-overlay-color); 
   font-size: inherit;
   outline-offset: 2px;
 }
@@ -99,14 +99,10 @@
   display: inline-block;
   width: 1em;
   height: 1em;
-  background-color: currentColor;
-  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="6" width="28" height="18" rx="3" stroke="black" stroke-width="1.5" fill="none"/><line x1="1" y1="15" x2="29" y2="15" stroke="black" stroke-width="1.5" stroke-linecap="butt"/></svg>');
+  background-color: currentcolor;
   mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="6" width="28" height="18" rx="3" stroke="black" stroke-width="1.5" fill="none"/><line x1="1" y1="15" x2="29" y2="15" stroke="black" stroke-width="1.5" stroke-linecap="butt"/></svg>');
-  -webkit-mask-size: contain;
   mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
-  -webkit-mask-position: center;
   mask-position: center;
   vertical-align: middle;
 }
@@ -122,4 +118,14 @@
     width: 125px;
     border-radius: 12px;
   }
+}
+
+.dmn-drd-container .dmn-decision-service-label {
+  display: none;
+}
+
+.dmn-drd-container
+  .djs-shape:is(.new-parent, .drop-ok, .drop-not-ok, .attach-ok)
+  .dmn-decision-service-label {
+  display: block;
 }

--- a/packages/dmn-js-drd/src/Modeler.js
+++ b/packages/dmn-js-drd/src/Modeler.js
@@ -4,6 +4,7 @@ import NavigatedViewer from './NavigatedViewer';
 
 import AlignElementsModule from 'diagram-js/lib/features/align-elements';
 import AutoPlaceModule from './features/auto-place';
+import AutoResizeModule from './features/auto-resize';
 import AutoScrollModule from 'diagram-js/lib/features/auto-scroll';
 import BendpointsModule from 'diagram-js/lib/features/bendpoints';
 import ContextPadModule from './features/context-pad';
@@ -119,6 +120,7 @@ Modeler.prototype._modelingModules = [
   // modeling components
   AlignElementsModule,
   AutoPlaceModule,
+  AutoResizeModule,
   AutoScrollModule,
   BendpointsModule,
   ContextPadModule,

--- a/packages/dmn-js-drd/src/Modeler.js
+++ b/packages/dmn-js-drd/src/Modeler.js
@@ -19,6 +19,7 @@ import KeyboardMoveSelectionModule from 'diagram-js/lib/features/keyboard-move-s
 import LabelEditingModule from './features/label-editing';
 import ModelingModule from './features/modeling';
 import MoveModule from 'diagram-js/lib/features/move';
+import OrderingProviderModule from './features/ordering';
 import OutlineProvider from './features/outline';
 import PaletteModule from './features/palette';
 import ResizeModule from 'diagram-js/lib/features/resize';
@@ -134,6 +135,7 @@ Modeler.prototype._modelingModules = [
   ModelingModule,
   MoveModule,
   OutlineProvider,
+  OrderingProviderModule,
   PaletteModule,
   ResizeModule,
   SnappingModule,

--- a/packages/dmn-js-drd/src/draw/DrdRenderer.js
+++ b/packages/dmn-js-drd/src/draw/DrdRenderer.js
@@ -348,6 +348,63 @@ export default function DrdRenderer(
 
       return rect;
     },
+     'dmn:DecisionService': function(p, element) {
+      var rect = drawRect(p, element.width, element.height, 12, {
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        strokeWidth: 4,
+        fill: getFillColor(element, defaultFillColor)
+      });
+
+      var dividerY = element.height / 2;
+      var line = svgCreate('line');
+      svgAttr(line, {
+        x1: 0,
+        y1: dividerY,
+        x2: element.width,
+        y2: dividerY,
+        stroke: getStrokeColor(element, defaultStrokeColor),
+        strokeWidth: 2
+      });
+      svgAppend(p, line);
+
+      var outputText = svgCreate('text');
+      svgAttr(outputText, {
+        x: element.width / 2,
+        y: dividerY - 10,
+        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor),
+        'font-family': 'Arial, sans-serif',
+        'font-weight': 'bold',
+        'font-size': '12px',
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle',
+        'display': 'none'
+      });
+      outputText.textContent = 'OUTPUT';
+      domAttr(outputText, 'class', 'djs-label dmn-decision-service-label');
+      svgAppend(p, outputText);
+
+      var encapsulatedText = svgCreate('text');
+      svgAttr(encapsulatedText, {
+        x: element.width / 2,
+        y: dividerY + 10,
+        fill: getLabelColor(element, defaultLabelColor, defaultStrokeColor),
+        'font-family': 'Arial, sans-serif',
+        'font-weight': 'bold',
+        'font-size': '12px',
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle',
+        'display': 'none'
+      });
+      encapsulatedText.textContent = 'ENCAPSULATED';
+      domAttr(encapsulatedText, 'class', 'djs-label dmn-decision-service-label');
+      svgAppend(p, encapsulatedText);
+
+      renderEmbeddedLabel(p, element, 'center-top', {
+        padding: 10
+      });
+
+      return rect;
+    },
     'dmn:TextAnnotation': function(p, element) {
       var style = {
         'fill': 'none',

--- a/packages/dmn-js-drd/src/draw/DrdRenderer.js
+++ b/packages/dmn-js-drd/src/draw/DrdRenderer.js
@@ -348,7 +348,7 @@ export default function DrdRenderer(
 
       return rect;
     },
-     'dmn:DecisionService': function(p, element) {
+    'dmn:DecisionService': function(p, element) {
       var rect = drawRect(p, element.width, element.height, 12, {
         stroke: getStrokeColor(element, defaultStrokeColor),
         strokeWidth: 4,

--- a/packages/dmn-js-drd/src/draw/DrdRenderer.js
+++ b/packages/dmn-js-drd/src/draw/DrdRenderer.js
@@ -355,7 +355,7 @@ export default function DrdRenderer(
         fill: getFillColor(element, defaultFillColor)
       });
 
-      var dividerY = element.height / 2;
+      var dividerY = element.height * getDecisionServiceDividerRatio(element.businessObject);
       var line = svgCreate('line');
       svgAttr(line, {
         x1: 0,
@@ -376,8 +376,7 @@ export default function DrdRenderer(
         'font-weight': 'bold',
         'font-size': '12px',
         'text-anchor': 'middle',
-        'dominant-baseline': 'middle',
-        'display': 'none'
+        'dominant-baseline': 'middle'
       });
       outputText.textContent = 'OUTPUT';
       domAttr(outputText, 'class', 'djs-label dmn-decision-service-label');
@@ -392,8 +391,7 @@ export default function DrdRenderer(
         'font-weight': 'bold',
         'font-size': '12px',
         'text-anchor': 'middle',
-        'dominant-baseline': 'middle',
-        'display': 'none'
+        'dominant-baseline': 'middle'
       });
       encapsulatedText.textContent = 'ENCAPSULATED';
       domAttr(encapsulatedText, 'class', 'djs-label dmn-decision-service-label');
@@ -594,4 +592,21 @@ function getFillColor(element, defaultColor) {
 
 function getLabelColor(element, defaultColor, defaultStrokeColor) {
   return defaultColor || getStrokeColor(element, defaultStrokeColor);
+}
+
+export function getDecisionServiceDividerRatio(businessObject) {
+  var di = businessObject && businessObject.di;
+  var dividerLine = di && di.decisionServiceDividerLine;
+  var bounds = di && di.bounds;
+
+  if (!dividerLine
+      || !dividerLine.waypoint
+      || dividerLine.waypoint.length !== 2
+      || !bounds
+      || !bounds.height) {
+    return 0.5;
+  }
+
+  var ratio = (dividerLine.waypoint[0].y - bounds.y) / bounds.height;
+  return Math.max(0, Math.min(1, ratio));
 }

--- a/packages/dmn-js-drd/src/features/auto-resize/DrdAutoResize.js
+++ b/packages/dmn-js-drd/src/features/auto-resize/DrdAutoResize.js
@@ -1,0 +1,29 @@
+import inherits from 'inherits-browser';
+import AutoResize from 'diagram-js/lib/features/auto-resize/AutoResize';
+import { is } from 'dmn-js-shared/lib/util/ModelUtil';
+
+/**
+ * DRD-specific auto-resize behavior.
+ * @param {Injector} injector
+ */
+
+export default function DrdAutoResize(injector) {
+  injector.invoke(AutoResize, this);
+}
+
+DrdAutoResize.$inject = [ 'injector' ];
+
+inherits(DrdAutoResize, AutoResize);
+
+/**
+ * Provide more specific padding for decision-service elements.
+ *
+ * @param {Shape} shape
+ *
+ */
+DrdAutoResize.prototype.getPadding = function(shape) {
+  if (is(shape, 'dmn:DecisionService')) {
+    return { top: 20, right: 20, bottom: 20, left: 20 };
+  }
+  return AutoResize.prototype.getPadding.call(this, shape);
+};

--- a/packages/dmn-js-drd/src/features/auto-resize/DrdAutoResizeProvider.js
+++ b/packages/dmn-js-drd/src/features/auto-resize/DrdAutoResizeProvider.js
@@ -1,0 +1,34 @@
+import inherits from 'inherits-browser';
+import AutoResizeProvider from 'diagram-js/lib/features/auto-resize/AutoResizeProvider';
+import { is } from 'dmn-js-shared/lib/util/ModelUtil';
+
+/**
+ * DRD-specific provider for auto-resize behavior.
+ * @param {EventBus} eventBus
+ */
+export default function DrdAutoResizeProvider(eventBus) {
+  AutoResizeProvider.call(this, eventBus);
+}
+
+DrdAutoResizeProvider.$inject = [ 'eventBus' ];
+
+inherits(DrdAutoResizeProvider, AutoResizeProvider);
+
+/**
+ * DRD-specific check for what elements should be auto-resized.
+ *
+ * @param {Shape[]} elements
+ * @param {Shape} target
+ *
+ * @return {boolean}
+ */
+
+DrdAutoResizeProvider.prototype.canResize = function(elements, target) {
+  if (!is(target, 'dmn:DecisionService')) {
+    return false;
+  }
+
+  return elements.every(function(element) {
+    return is(element, 'dmn:Decision') && !element.labelTarget;
+  });
+};

--- a/packages/dmn-js-drd/src/features/auto-resize/index.js
+++ b/packages/dmn-js-drd/src/features/auto-resize/index.js
@@ -1,0 +1,11 @@
+import AutoResizeModule from 'diagram-js/lib/features/auto-resize';
+import RulesModule from '../rules';
+import DrdAutoResizeProvider from './DrdAutoResizeProvider';
+import DrdAutoResize from './DrdAutoResize';
+
+export default {
+  __depends__: [ AutoResizeModule,	RulesModule ],
+  __init__: [ 'drdAutoResizeProvider' ],
+  autoResize: [ 'type', DrdAutoResize ],
+  drdAutoResizeProvider: [ 'type', DrdAutoResizeProvider ]
+};

--- a/packages/dmn-js-drd/src/features/context-pad/ContextPadProvider.js
+++ b/packages/dmn-js-drd/src/features/context-pad/ContextPadProvider.js
@@ -163,7 +163,7 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
     };
   }
 
-  if (is(businessObject, 'dmn:Decision')) {
+  if (isAny(businessObject, [ 'dmn:Decision', 'dmn:DecisionService' ])) {
     assign(actions, {
       'append.decision': appendAction(
         'dmn:Decision',
@@ -191,7 +191,8 @@ ContextPadProvider.prototype.getContextPadEntries = function(element) {
 
   if (isAny(businessObject, [
     'dmn:BusinessKnowledgeModel',
-    'dmn:Decision'
+    'dmn:Decision',
+    'dmn:DecisionService'
   ])) {
     assign(actions, {
       'append.business-knowledge-model': appendAction(

--- a/packages/dmn-js-drd/src/features/label-editing/LabelEditingProvider.js
+++ b/packages/dmn-js-drd/src/features/label-editing/LabelEditingProvider.js
@@ -117,9 +117,13 @@ LabelEditingProvider.prototype.activate = function(element) {
 
   // DRG elements
   if (is(element, 'dmn:DRGElement')) {
-    assign(options, {
-      centerVertically: true
-    });
+
+    // Exception not to center vertically for DecisionService
+    if (!is(element, 'dmn:DecisionService')) {
+      assign(options, {
+        centerVertically: true
+      });
+    }
 
     assign(style, {
       backgroundColor: null,

--- a/packages/dmn-js-drd/src/features/label-editing/LabelUtil.js
+++ b/packages/dmn-js-drd/src/features/label-editing/LabelUtil.js
@@ -7,7 +7,9 @@ function getLabelAttr(semantic) {
   if (is(semantic, 'dmn:Decision') ||
       is(semantic, 'dmn:BusinessKnowledgeModel') ||
       is(semantic, 'dmn:InputData') ||
-      is(semantic, 'dmn:KnowledgeSource')) {
+      is(semantic, 'dmn:KnowledgeSource') ||
+      is(semantic, 'dmn:DecisionService')
+  ) {
 
     return 'name';
   }

--- a/packages/dmn-js-drd/src/features/modeling/DrdFactory.js
+++ b/packages/dmn-js-drd/src/features/modeling/DrdFactory.js
@@ -73,3 +73,9 @@ DrdFactory.prototype.createDiWaypoint = function(waypoint) {
 DrdFactory.prototype.createExtensionElements = function() {
   return this.create('dmn:ExtensionElements', { values: [] });
 };
+
+DrdFactory.prototype.createDiDividerLine = function(waypoints) {
+  return this.create('dmndi:DMNDecisionServiceDividerLine', {
+    waypoint: this.createDiWaypoints(waypoints)
+  });
+};

--- a/packages/dmn-js-drd/src/features/modeling/DrdUpdater.js
+++ b/packages/dmn-js-drd/src/features/modeling/DrdUpdater.js
@@ -277,6 +277,25 @@ DrdUpdater.prototype.updateBounds = function(shape) {
     width: shape.width,
     height: shape.height
   });
+
+  // update decision service divider line
+  if (is(shape, 'dmn:DecisionService') && businessObject.di.decisionServiceDividerLine) {
+    var dividerY = shape.y + (shape.height / 2);
+    var dividerLine = businessObject.di.decisionServiceDividerLine;
+
+    if (dividerLine.waypoint && dividerLine.waypoint.length === 2) {
+      assign(dividerLine.waypoint[0], {
+        x: shape.x,
+        y: dividerY
+      });
+
+
+      assign(dividerLine.waypoint[1], {
+        x: shape.x + shape.width,
+        y: dividerY
+      });
+    }
+  }
 };
 
 DrdUpdater.prototype.updateConnectionWaypoints = function(context) {
@@ -322,13 +341,6 @@ DrdUpdater.prototype.updateSemanticParent = function(businessObject, parent) {
 
     // Find the Definitions element (Decision still remains under Definitions)
     var definitions = parent.$parent;
-
-    if (!definitions || !is(definitions, 'dmn:Definitions')) {
-      definitions = parent;
-      while (definitions && !is(definitions, 'dmn:Definitions')) {
-        definitions = definitions.$parent;
-      }
-    }
 
     // In case the decision was previously referenced by any services, clean up first
     if (definitions) {

--- a/packages/dmn-js-drd/src/features/modeling/DrdUpdater.js
+++ b/packages/dmn-js-drd/src/features/modeling/DrdUpdater.js
@@ -14,6 +14,8 @@ import {
 
 import CommandInterceptor from 'diagram-js/lib/command/CommandInterceptor';
 
+import { getDecisionServiceDividerRatio } from '../../draw/DrdRenderer';
+
 
 /**
  * Update DMN 1.3 information.
@@ -270,6 +272,11 @@ DrdUpdater.prototype.updateBounds = function(shape) {
   var businessObject = shape.businessObject,
       bounds = businessObject.di.bounds;
 
+  var dividerLine = is(shape, 'dmn:DecisionService')
+    && businessObject.di.decisionServiceDividerLine;
+
+  var dividerRatio = dividerLine && getDecisionServiceDividerRatio(businessObject);
+
   // update bounds
   assign(bounds, {
     x: shape.x,
@@ -279,22 +286,21 @@ DrdUpdater.prototype.updateBounds = function(shape) {
   });
 
   // update decision service divider line
-  if (is(shape, 'dmn:DecisionService') && businessObject.di.decisionServiceDividerLine) {
-    var dividerY = shape.y + (shape.height / 2);
-    var dividerLine = businessObject.di.decisionServiceDividerLine;
+  if (dividerLine
+      && dividerLine.waypoint
+      && dividerLine.waypoint.length === 2) {
 
-    if (dividerLine.waypoint && dividerLine.waypoint.length === 2) {
-      assign(dividerLine.waypoint[0], {
-        x: shape.x,
-        y: dividerY
-      });
+    var dividerY = shape.y + (shape.height * dividerRatio);
 
+    assign(dividerLine.waypoint[0], {
+      x: shape.x,
+      y: dividerY
+    });
 
-      assign(dividerLine.waypoint[1], {
-        x: shape.x + shape.width,
-        y: dividerY
-      });
-    }
+    assign(dividerLine.waypoint[1], {
+      x: shape.x + shape.width,
+      y: dividerY
+    });
   }
 };
 

--- a/packages/dmn-js-drd/src/features/modeling/ElementFactory.js
+++ b/packages/dmn-js-drd/src/features/modeling/ElementFactory.js
@@ -12,6 +12,7 @@ import BaseElementFactory from 'diagram-js/lib/core/ElementFactory';
 
 export var BUSINESS_KNOWLEDGE_MODEL_SIZE = { width: 135, height: 46 };
 export var DECISION_SIZE = { width: 180, height: 80 };
+export var DECISION_SERVICE_SIZE = { width: 320, height: 320 };
 export var INPUT_DATA_SIZE = { width: 125, height: 45 };
 export var KNOWLEDGE_SOURCE_SIZE = { width: 100, height: 63 };
 
@@ -58,6 +59,31 @@ ElementFactory.prototype.createDrdElement = function(elementType, attrs) {
       businessObject.di = drdFactory.createDiEdge(businessObject, []);
     } else if (elementType === 'shape') {
       businessObject.di = drdFactory.createDiShape(businessObject, {});
+
+
+      if (is(businessObject, 'dmn:DecisionService')) {
+        size = this._getDefaultSize(businessObject);
+        var dividerY = (attrs.y || 0) + (size.height / 2);
+        var dividerWaypoints = [
+          { x: attrs.x || 0, y: dividerY },
+          { x: (attrs.x || 0) + size.width, y: dividerY }
+        ];
+        businessObject.di.decisionServiceDividerLine = drdFactory.createDiDividerLine(dividerWaypoints);
+
+        // Set default name if not provided
+        if (!businessObject.name) {
+          businessObject.name = 'New Decision Service';
+        }
+
+        // Create variable for Decision Service
+        if (!businessObject.variable) {
+          var variable = drdFactory.create('dmn:InformationItem', {
+            name: businessObject.name
+          });
+          businessObject.variable = variable;
+          variable.$parent = businessObject;
+        }
+      }
     }
   }
 
@@ -79,6 +105,10 @@ ElementFactory.prototype._getDefaultSize = function(semantic) {
 
   if (is(semantic, 'dmn:Decision')) {
     return DECISION_SIZE;
+  }
+
+  if (is(semantic, 'dmn:DecisionService')) {
+    return DECISION_SERVICE_SIZE;
   }
 
   if (is(semantic, 'dmn:InputData')) {

--- a/packages/dmn-js-drd/src/features/modeling/behavior/CreateConnectionBehavior.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/CreateConnectionBehavior.js
@@ -60,7 +60,7 @@ inherits(CreateConnectionBehavior, CommandInterceptor);
 // helpers //////////
 
 function getRequirementType(source) {
-  if (is(source, 'dmn:BusinessKnowledgeModel')) {
+  if (is(source, 'dmn:BusinessKnowledgeModel') || is(source, 'dmn:dmn:DecisionService')) {
     return 'Knowledge';
   } else if (is(source, 'dmn:Decision')) {
     return 'Decision';

--- a/packages/dmn-js-drd/src/features/modeling/behavior/CreateConnectionBehavior.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/CreateConnectionBehavior.js
@@ -60,7 +60,7 @@ inherits(CreateConnectionBehavior, CommandInterceptor);
 // helpers //////////
 
 function getRequirementType(source) {
-  if (is(source, 'dmn:BusinessKnowledgeModel') || is(source, 'dmn:dmn:DecisionService')) {
+  if (is(source, 'dmn:BusinessKnowledgeModel') || is(source, 'dmn:DecisionService')) {
     return 'Knowledge';
   } else if (is(source, 'dmn:Decision')) {
     return 'Decision';

--- a/packages/dmn-js-drd/src/features/modeling/behavior/DecisionServiceBehavior.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/DecisionServiceBehavior.js
@@ -1,0 +1,506 @@
+import {
+  add as collectionAdd,
+  remove as collectionRemove
+} from 'diagram-js/lib/util/Collections';
+
+import { is } from 'dmn-js-shared/lib/util/ModelUtil';
+
+export default function DecisionServiceBehavior(drdFactory, injector, eventBus) {
+  this._drdFactory = drdFactory;
+  this._injector = injector;
+  this._elementRegistry = null;
+  this._eventBus = eventBus;
+
+  var self = this;
+
+  // Listen to drag events to show/hide decision service section labels
+  eventBus.on('drag.start', function() {
+    self._updateDecisionServiceLabelsVisibility(true);
+  });
+
+  eventBus.on([ 'drag.end', 'drag.cancel' ], function() {
+    self._updateDecisionServiceLabelsVisibility(false);
+  });
+}
+
+DecisionServiceBehavior.$inject = [ 'drdFactory', 'injector', 'eventBus' ];
+
+/**
+ * Get the element registry
+ * @returns {ElementRegistry}
+ */
+DecisionServiceBehavior.prototype._getElementRegistry = function() {
+  if (!this._elementRegistry) {
+    this._elementRegistry = this._injector.get('elementRegistry');
+  }
+  return this._elementRegistry;
+};
+
+/**
+ * Update the visibility of decision service section labels (OUTPUT/ENCAPSULATED)
+ * @param {boolean} visible - Whether to show or hide the labels
+ */
+DecisionServiceBehavior.prototype._updateDecisionServiceLabelsVisibility = function(visible) {
+  var labels = document.querySelectorAll('.dmn-decision-service-label');
+  labels.forEach(function(label) {
+    label.style.display = visible ? 'block' : 'none';
+  });
+};
+
+/**
+ * Get the divider Y position for a decision service
+ * @param {Element} decisionServiceElement - The decision service element
+ * @returns {number} The Y position of the divider line
+ */
+DecisionServiceBehavior.prototype._getDividerPosition = function(decisionServiceElement) {
+  return decisionServiceElement.y + (decisionServiceElement.height / 2);
+};
+
+/**
+ * Determines if a decision should be in the "output" (top) or "encapsulated" (bottom) section
+ * based on its Y position relative to the divider line.
+ *
+ * @param {Element} decisionElement - The decision element
+ * @param {ModdleElement} decisionServiceBo - The decision service business object
+ * @returns {boolean} true if decision should be in output section, false for encapsulated
+ */
+DecisionServiceBehavior.prototype.isOutputDecision = function(decisionElement, decisionServiceBo) {
+  var decisionServiceElement = this._getElementRegistry().get(decisionServiceBo.id);
+
+  if (!decisionServiceElement) {
+    return false;
+  }
+
+  // Get divider line Y position
+  var dividerY = this._getDividerPosition(decisionServiceElement);
+
+  // Check if decision's Y position is above the divider line
+  var decisionCenterY = decisionElement.y + (decisionElement.height / 2);
+
+  return decisionCenterY < dividerY;
+};
+
+/**
+ * Handle Decision being moved into DecisionService.
+ *
+ * @param {ModdleElement} decisionBo - The decision business object
+ * @param {ModdleElement} decisionServiceBo - The decision service business object
+ * @param {ModdleElement} definitions - The definitions element
+ */
+DecisionServiceBehavior.prototype.addDecisionToService = function(decisionBo, decisionServiceBo, definitions) {
+  var children;
+
+  // Ensure the decision is in Definitions' drgElement collection
+  if (definitions) {
+    children = definitions.get('drgElement');
+    if (!children) {
+      definitions.drgElement = [];
+      children = definitions.drgElement;
+    }
+    if (children.indexOf(decisionBo) === -1) {
+      collectionAdd(children, decisionBo);
+    }
+
+    // Keep the $parent as Definitions, not DecisionService
+    decisionBo.$parent = definitions;
+  }
+
+  // Get the element from the registry to check its position
+  var decisionElement = this._getElementRegistry().get(decisionBo.id);
+
+  var isOutputDecision = this.isOutputDecision(decisionElement, decisionServiceBo);
+
+  if (isOutputDecision) {
+    children = decisionServiceBo.get('outputDecision');
+    if (!children) {
+      decisionServiceBo.outputDecision = [];
+      children = decisionServiceBo.outputDecision;
+    }
+  } else {
+    children = decisionServiceBo.get('encapsulatedDecision');
+    if (!children) {
+      decisionServiceBo.encapsulatedDecision = [];
+      children = decisionServiceBo.encapsulatedDecision;
+    }
+  }
+
+  // Create DMNElementReference (not moving the actual decision)
+  var reference = this._drdFactory.create('dmn:DMNElementReference', {
+    href: '#' + decisionBo.id
+  });
+
+  // Only add the reference if it doesn't already exist
+  var existingRef = children.find(function(r) { return r.href === '#' + decisionBo.id; });
+  if (!existingRef) {
+    collectionAdd(children, reference);
+  }
+
+  // Update inputDecision and inputData based on output decisions
+  this.updateInputsFromOutputDecisions(decisionServiceBo);
+};
+
+
+/**
+ * Handle Decision being moved out of DecisionService back to root level.
+ *
+ * @param {ModdleElement} decisionBo - The decision business object
+ * @param {ModdleElement} definitions - The definitions element
+ */
+DecisionServiceBehavior.prototype.removeDecisionFromServices = function(decisionBo, definitions) {
+  var self = this;
+  var drgElements = definitions.get('drgElement');
+
+  if (drgElements) {
+    drgElements.forEach(function(element) {
+      if (is(element, 'dmn:DecisionService')) {
+
+        // Remove the decision reference from this service
+        self.removeDecisionFromService(decisionBo, element);
+      }
+    });
+  }
+
+  // Ensure the decision is in Definitions' drgElement collection
+  var children = definitions.get('drgElement');
+  if (children && children.indexOf(decisionBo) === -1) {
+    collectionAdd(children, decisionBo);
+  }
+  decisionBo.$parent = definitions;
+};
+
+
+
+/**
+ * Remove a decision from a DecisionService.
+ *
+ * @param {ModdleElement} decisionBo - The decision business object
+ * @param {ModdleElement} decisionServiceBo - The decision service business object
+ */
+DecisionServiceBehavior.prototype.removeDecisionFromService = function(decisionBo, decisionServiceBo) {
+  var children = decisionServiceBo.get('encapsulatedDecision');
+  var ref;
+
+  if (children) {
+    ref = children.find(function(d) { return d.href === '#' + decisionBo.id; });
+    if (ref) {
+      collectionRemove(children, ref);
+    }
+  }
+
+  children = decisionServiceBo.get('outputDecision');
+  if (children) {
+    ref = children.find(function(d) { return d.href === '#' + decisionBo.id; });
+    if (ref) {
+      collectionRemove(children, ref);
+    }
+  }
+
+  // Update inputDecision and inputData based on remaining output decisions
+  this.updateInputsFromOutputDecisions(decisionServiceBo);
+};
+
+
+/**
+ * Update which section a decision belongs to when moved within a DecisionService.
+ *
+ * @param {Element} decisionElement - The decision shape element
+ * @param {ModdleElement} decisionServiceBo - The decision service business object
+ */
+DecisionServiceBehavior.prototype.updateDecisionSection = function(decisionElement, decisionServiceBo) {
+  var decisionBo = decisionElement.businessObject;
+
+  // Determine which section the decision should be in based on position
+  var isOutputDecision = this.isOutputDecision(decisionElement, decisionServiceBo);
+
+  // Get current collections
+  var outputDecisions = decisionServiceBo.get('outputDecision') || [];
+  var encapsulatedDecisions = decisionServiceBo.get('encapsulatedDecision') || [];
+
+  // Check if decision is already in the correct section
+  var decisionHref = '#' + decisionBo.id;
+  var inOutputDecisions = outputDecisions.some(function(d) { return d.href === decisionHref; });
+  var inEncapsulatedDecisions = encapsulatedDecisions.some(function(d) { return d.href === decisionHref; });
+
+  if (isOutputDecision && inOutputDecisions) {
+    return;
+  }
+
+  if (!isOutputDecision && inEncapsulatedDecisions) {
+    return;
+  }
+
+  // Remove from current section
+  this.removeDecisionFromService(decisionBo, decisionServiceBo);
+
+  // Add to correct section
+  var reference = this._drdFactory.create('dmn:DMNElementReference', {
+    href: decisionHref
+  });
+
+  if (isOutputDecision) {
+    if (!decisionServiceBo.outputDecision) {
+      decisionServiceBo.outputDecision = [];
+    }
+    collectionAdd(decisionServiceBo.outputDecision, reference);
+  } else {
+    if (!decisionServiceBo.encapsulatedDecision) {
+      decisionServiceBo.encapsulatedDecision = [];
+    }
+    collectionAdd(decisionServiceBo.encapsulatedDecision, reference);
+  }
+
+  // Update inputDecision and inputData based on output decisions
+  this.updateInputsFromOutputDecisions(decisionServiceBo);
+};
+
+/**
+ * Traverse output decisions and automatically populate inputDecision and inputData
+ * based on their direct connections using graph traversal.
+ *
+ * @param {ModdleElement} decisionServiceBo - The decision service business object
+ */
+DecisionServiceBehavior.prototype.updateInputsFromOutputDecisions = function(decisionServiceBo) {
+  var elementRegistry = this._getElementRegistry();
+
+  var outputDecisions = decisionServiceBo.get('outputDecision') || [];
+  var encapsulatedDecisions = decisionServiceBo.get('encapsulatedDecision') || [];
+
+  // Create a set of all decisions within this service (output + encapsulated)
+  var decisionsInService = new Set();
+  outputDecisions.forEach(function(ref) {
+    decisionsInService.add(ref.href.substring(1)); // Remove '#'
+  });
+  encapsulatedDecisions.forEach(function(ref) {
+    decisionsInService.add(ref.href.substring(1)); // Remove '#'
+  });
+
+  var inputDecisionIds = new Set();
+  var inputDataIds = new Set();
+
+  // Helper function to traverse a decision's dependencies using BFS
+  var traverseDecision = function(decisionId, visited) {
+
+    // Avoid cycles
+    if (visited.has(decisionId)) {
+      return;
+    }
+    visited.add(decisionId);
+
+    var decisionElement = elementRegistry.get(decisionId);
+    if (!decisionElement) {
+      return;
+    }
+
+    var informationRequirements = decisionElement.businessObject.get('informationRequirement') || [];
+
+    informationRequirements.forEach(function(infoReq) {
+
+      // Handle required decisions
+      if (infoReq.requiredDecision) {
+        var requiredDecisionId = infoReq.requiredDecision.href.substring(1);
+
+        // If this decision is NOT in the service, it's an input decision
+        if (!decisionsInService.has(requiredDecisionId)) {
+          inputDecisionIds.add(requiredDecisionId);
+        } else {
+
+          // If it's in the service (encapsulated), continue traversing
+          traverseDecision(requiredDecisionId, visited);
+        }
+      }
+
+      // Handle required input data
+      if (infoReq.requiredInput) {
+        var requiredInputId = infoReq.requiredInput.href.substring(1);
+        inputDataIds.add(requiredInputId);
+      }
+    });
+  };
+
+  // Start traversal from each output decision
+  var visited = new Set();
+  outputDecisions.forEach(function(outputDecisionRef) {
+    var decisionId = outputDecisionRef.href.substring(1);
+    traverseDecision(decisionId, visited);
+  });
+
+  // Update inputDecision collection
+  this._updateReferenceCollection(
+    decisionServiceBo,
+    'inputDecision',
+    inputDecisionIds,
+    elementRegistry
+  );
+
+  // Update inputData collection
+  this._updateReferenceCollection(
+    decisionServiceBo,
+    'inputData',
+    inputDataIds,
+    elementRegistry
+  );
+};
+
+/**
+ * Helper method to update a reference collection (inputDecision or inputData)
+ * @param {ModdleElement} decisionServiceBo - The decision service business object
+ * @param {string} collectionName - Name of the collection ('inputDecision' or 'inputData')
+ * @param {Set} newIds - Set of element IDs that should be in the collection
+ * @param {ElementRegistry} elementRegistry - The element registry
+ */
+DecisionServiceBehavior.prototype._updateReferenceCollection = function(
+    decisionServiceBo,
+    collectionName,
+    newIds,
+    elementRegistry
+) {
+  var self = this;
+  var currentCollection = decisionServiceBo.get(collectionName) || [];
+  var currentIds = new Set();
+
+  currentCollection.forEach(function(ref) {
+    currentIds.add(ref.href.substring(1));
+  });
+
+  // Add new references
+  newIds.forEach(function(elementId) {
+    if (!currentIds.has(elementId)) {
+
+      // Verify the element still exists before adding reference
+      var element = elementRegistry.get(elementId);
+      if (element) {
+        if (!decisionServiceBo[collectionName]) {
+          decisionServiceBo[collectionName] = [];
+        }
+        var reference = self._drdFactory.create('dmn:DMNElementReference', {
+          href: '#' + elementId
+        });
+        collectionAdd(decisionServiceBo[collectionName], reference);
+      }
+    }
+  });
+
+  // Remove references that are no longer needed
+  var referencesToRemove = [];
+  currentCollection.forEach(function(ref) {
+    var elementId = ref.href.substring(1);
+    if (!newIds.has(elementId)) {
+      referencesToRemove.push(ref);
+    }
+  });
+  referencesToRemove.forEach(function(ref) {
+    collectionRemove(decisionServiceBo[collectionName], ref);
+  });
+};
+
+/**
+ * Update all decision services that contain the given decision element.
+ * This should be called when information requirements change.
+ *
+ * @param {Element} decisionElement - The decision element whose requirements changed
+ * @param {ModdleElement} definitions - The definitions business object
+ */
+DecisionServiceBehavior.prototype.updateServicesContainingDecision = function(decisionElement, definitions) {
+  if (!decisionElement || !is(decisionElement.businessObject, 'dmn:Decision')) {
+    return;
+  }
+
+  if (!definitions || !is(definitions, 'dmn:Definitions')) {
+    return;
+  }
+
+  var drgElements = definitions.get('drgElement') || [];
+  var decisionId = decisionElement.businessObject.id;
+  var self = this;
+
+  // Find all decision services and update them if they contain this decision
+  drgElements.forEach(function(element) {
+    if (is(element, 'dmn:DecisionService')) {
+      var outputDecisions = element.get('outputDecision') || [];
+      var encapsulatedDecisions = element.get('encapsulatedDecision') || [];
+
+      // Check if this decision is in the service (output or encapsulated)
+      var isInService = outputDecisions.some(function(ref) {
+        return ref.href === '#' + decisionId;
+      }) || encapsulatedDecisions.some(function(ref) {
+        return ref.href === '#' + decisionId;
+      });
+
+      if (isInService) {
+
+        // Update the decision service's inputs
+        self.updateInputsFromOutputDecisions(element);
+      }
+    }
+  });
+};
+
+/**
+ * Remove references to a deleted element from all decision services.
+ * This should be called when a decision or input data is deleted.
+ *
+ * @param {string} deletedId - The ID of the deleted element
+ * @param {ModdleElement} definitions - The definitions business object
+ */
+DecisionServiceBehavior.prototype.removeElementFromAllServices = function(deletedId, definitions) {
+  if (!deletedId || !definitions || !is(definitions, 'dmn:Definitions')) {
+    return;
+  }
+
+  var drgElements = definitions.get('drgElement') || [];
+  var self = this;
+  var deletedHref = '#' + deletedId;
+
+  // Find all decision services and remove references to the deleted element
+  drgElements.forEach(function(element) {
+    if (is(element, 'dmn:DecisionService')) {
+      var needsUpdate = false;
+
+      // Helper to remove from a collection
+      var removeFromCollection = function(collectionName) {
+        var collection = element.get(collectionName) || [];
+        var toRemove = collection.filter(function(ref) {
+          return ref.href === deletedHref;
+        });
+
+        if (toRemove.length > 0) {
+          toRemove.forEach(function(ref) {
+            collectionRemove(element[collectionName], ref);
+          });
+          needsUpdate = true;
+        }
+      };
+
+      // Remove from all possible collections
+      removeFromCollection('outputDecision');
+      removeFromCollection('encapsulatedDecision');
+      removeFromCollection('inputDecision');
+      removeFromCollection('inputData');
+
+      // If we removed from output/encapsulated, recalculate inputs
+      if (needsUpdate) {
+        self.updateInputsFromOutputDecisions(element);
+      }
+    }
+  });
+};
+
+/**
+ * Update all decision services by recalculating their inputs.
+ * @param {ModdleElement} definitions - The definitions business object
+ */
+DecisionServiceBehavior.prototype.updateAllServices = function(definitions) {
+  if (!definitions || !is(definitions, 'dmn:Definitions')) {
+    return;
+  }
+
+  var drgElements = definitions.get('drgElement') || [];
+  var self = this;
+
+  // Update all decision services
+  drgElements.forEach(function(element) {
+    if (is(element, 'dmn:DecisionService')) {
+      self.updateInputsFromOutputDecisions(element);
+    }
+  });
+};

--- a/packages/dmn-js-drd/src/features/modeling/behavior/DecisionServiceBehavior.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/DecisionServiceBehavior.js
@@ -5,25 +5,21 @@ import {
 
 import { is } from 'dmn-js-shared/lib/util/ModelUtil';
 
+import { getDecisionServiceDividerRatio } from '../../../draw/DrdRenderer';
+
+
 export default function DecisionServiceBehavior(drdFactory, injector, eventBus) {
   this._drdFactory = drdFactory;
   this._injector = injector;
   this._elementRegistry = null;
   this._eventBus = eventBus;
-
-  var self = this;
-
-  // Listen to drag events to show/hide decision service section labels
-  eventBus.on('drag.start', function() {
-    self._updateDecisionServiceLabelsVisibility(true);
-  });
-
-  eventBus.on([ 'drag.end', 'drag.cancel' ], function() {
-    self._updateDecisionServiceLabelsVisibility(false);
-  });
 }
 
-DecisionServiceBehavior.$inject = [ 'drdFactory', 'injector', 'eventBus' ];
+DecisionServiceBehavior.$inject = [
+  'drdFactory',
+  'injector',
+  'eventBus'
+];
 
 /**
  * Get the element registry
@@ -37,23 +33,14 @@ DecisionServiceBehavior.prototype._getElementRegistry = function() {
 };
 
 /**
- * Update the visibility of decision service section labels (OUTPUT/ENCAPSULATED)
- * @param {boolean} visible - Whether to show or hide the labels
- */
-DecisionServiceBehavior.prototype._updateDecisionServiceLabelsVisibility = function(visible) {
-  var labels = document.querySelectorAll('.dmn-decision-service-label');
-  labels.forEach(function(label) {
-    label.style.display = visible ? 'block' : 'none';
-  });
-};
-
-/**
  * Get the divider Y position for a decision service
  * @param {Element} decisionServiceElement - The decision service element
  * @returns {number} The Y position of the divider line
  */
 DecisionServiceBehavior.prototype._getDividerPosition = function(decisionServiceElement) {
-  return decisionServiceElement.y + (decisionServiceElement.height / 2);
+  var ratio = getDecisionServiceDividerRatio(decisionServiceElement.businessObject);
+
+  return decisionServiceElement.y + (decisionServiceElement.height * ratio);
 };
 
 /**

--- a/packages/dmn-js-drd/src/features/modeling/behavior/index.js
+++ b/packages/dmn-js-drd/src/features/modeling/behavior/index.js
@@ -1,4 +1,5 @@
 import CreateConnectionBehavior from './CreateConnectionBehavior';
+import DecisionServiceBehavior from './DecisionServiceBehavior';
 import CreateShapeBehavior from './CreateShapeBehavior';
 import LayoutConnectionBehavior from './LayoutConnectionBehavior';
 import ReplaceConnectionBehavior from './ReplaceConnectionBehavior';
@@ -10,6 +11,7 @@ import NameChangeBehavior from
 export default {
   __init__: [
     'createConnectionBehavior',
+    'decisionServiceBehavior',
     'createShapeBehavior',
     'idChangeBehavior',
     'nameChangeBehavior',
@@ -18,6 +20,7 @@ export default {
     'replaceElementBehavior'
   ],
   createConnectionBehavior: [ 'type', CreateConnectionBehavior ],
+  decisionServiceBehavior: [ 'type', DecisionServiceBehavior ],
   createShapeBehavior: [ 'type', CreateShapeBehavior ],
   idChangeBehavior: [ 'type', IdChangeBehavior ],
   nameChangeBehavior: [ 'type', NameChangeBehavior ],

--- a/packages/dmn-js-drd/src/features/ordering/DmnOrderingProvider.js
+++ b/packages/dmn-js-drd/src/features/ordering/DmnOrderingProvider.js
@@ -1,0 +1,134 @@
+import inherits from 'inherits-browser';
+
+import OrderingProvider from 'diagram-js/lib/features/ordering/OrderingProvider';
+
+import {
+  is,
+  isAny
+} from 'dmn-js-shared/lib/util/ModelUtil';
+
+import {
+  findIndex,
+  find
+} from 'min-dash';
+
+/**
+ * @typedef {import('diagram-js/lib/core/Canvas').default} Canvas
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ */
+
+/**
+ * A DMN-specific ordering provider.
+ *
+ * @param {EventBus} eventBus
+ * @param {Canvas} canvas
+ */
+export default function DmnOrderingProvider(eventBus, canvas) {
+
+  OrderingProvider.call(this, eventBus);
+
+  const orders = [
+
+    // associations and requirements are rendered on top of everything else
+    { type: 'dmn:Association', order: { level: 9 } },
+    { type: 'dmn:AuthorityRequirement', order: { level: 9 } },
+    { type: 'dmn:InformationRequirement', order: { level: 9 } },
+    { type: 'dmn:KnowledgeRequirement', order: { level: 9 } },
+    { type: 'dmn:Artifact', order: { level: 8 } },
+    { type: 'dmn:DRGElement', order: { level: 2 }, containers: [ 'dmn:DecisionService' ] },
+  ];
+
+  function computeOrder(element) {
+    const entry = find(orders, function(o) {
+      return isAny(element, [ o.type ]);
+    });
+
+    return entry && entry.order || { level: 1 };
+  }
+
+  function getOrder(element) {
+
+    let order = element.order;
+
+    if (!order) {
+      element.order = order = computeOrder(element);
+    }
+
+    if (!order) {
+      throw new Error(`no order for <${ element.id }>`);
+    }
+
+    return order;
+  }
+
+  function findActualParent(element, newParent, containers) {
+
+    let actualParent = newParent;
+
+    while (actualParent) {
+
+      if (isAny(actualParent, containers)) {
+        break;
+      }
+
+      actualParent = actualParent.parent;
+    }
+
+    if (!actualParent) {
+      throw new Error(`no parent for <${ element.id }> in <${ newParent && newParent.id }>`);
+    }
+
+    return actualParent;
+  }
+
+  this.getOrdering = function(element, newParent) {
+
+    // render labels and text annotations always on top
+    if (element.labelTarget || is(element, 'bpmn:TextAnnotation')) {
+      return {
+        parent: canvas.findRoot(newParent) || canvas.getRootElement(),
+        index: -1
+      };
+    }
+
+    const elementOrder = getOrder(element);
+
+    if (elementOrder.containers) {
+      newParent = findActualParent(element, newParent, elementOrder.containers);
+    }
+
+    let currentIndex = newParent.children.indexOf(element);
+
+    let insertIndex = findIndex(newParent.children, function(child) {
+
+      // do not compare with labels, they are created
+      // in the wrong order (right after elements) during import and
+      // mess up the positioning.
+      if (!element.labelTarget && child.labelTarget) {
+        return false;
+      }
+
+      return elementOrder.level < getOrder(child).level;
+    });
+
+
+    // if the element is already in the child list at
+    // a smaller index, we need to adjust the insert index.
+    // this takes into account that the element is being removed
+    // before being re-inserted
+    if (insertIndex !== -1) {
+      if (currentIndex !== -1 && currentIndex < insertIndex) {
+        insertIndex -= 1;
+      }
+    }
+
+    return {
+      index: insertIndex,
+      parent: newParent
+    };
+  };
+}
+
+DmnOrderingProvider.$inject = [ 'eventBus', 'canvas' ];
+
+inherits(DmnOrderingProvider, OrderingProvider);

--- a/packages/dmn-js-drd/src/features/ordering/DmnOrderingProvider.js
+++ b/packages/dmn-js-drd/src/features/ordering/DmnOrderingProvider.js
@@ -84,7 +84,7 @@ export default function DmnOrderingProvider(eventBus, canvas) {
   this.getOrdering = function(element, newParent) {
 
     // render labels and text annotations always on top
-    if (element.labelTarget || is(element, 'bpmn:TextAnnotation')) {
+    if (element.labelTarget || is(element, 'dmn:TextAnnotation')) {
       return {
         parent: canvas.findRoot(newParent) || canvas.getRootElement(),
         index: -1

--- a/packages/dmn-js-drd/src/features/ordering/index.js
+++ b/packages/dmn-js-drd/src/features/ordering/index.js
@@ -1,0 +1,6 @@
+import DmnOrderingProvider from './DmnOrderingProvider';
+
+export default {
+  __init__: [ 'dmnOrderingProvider' ],
+  dmnOrderingProvider: [ 'type', DmnOrderingProvider ]
+};

--- a/packages/dmn-js-drd/src/features/palette/PaletteProvider.js
+++ b/packages/dmn-js-drd/src/features/palette/PaletteProvider.js
@@ -96,7 +96,12 @@ PaletteProvider.prototype.getPaletteEntries = function(element) {
     'create.business-knowledge-model': createAction(
       'dmn:BusinessKnowledgeModel', 'drd', 'dmn-icon-business-knowledge',
       translate('Create knowledge model')
-    )
+    ),
+    'create.decision-service': createAction(
+      'dmn:DecisionService', 'drd', 'dmn-icon-decision-service',
+      translate('Create decision service')
+    ),
+
   });
 
   return actions;

--- a/packages/dmn-js-drd/src/import/DrdImporter.js
+++ b/packages/dmn-js-drd/src/import/DrdImporter.js
@@ -39,11 +39,14 @@ DrdImporter.prototype.root = function(semantic) {
 /**
  * Add drd element (semantic) to the canvas.
  */
-DrdImporter.prototype.add = function(semantic) {
+DrdImporter.prototype.add = function(semantic, parentSemantic) {
   var elementFactory = this._elementFactory,
       canvas = this._canvas,
       eventBus = this._eventBus,
-      di = semantic.di;
+      di = semantic.di,
+      parent;
+
+  parent = parentSemantic && this._getShape(parentSemantic.id);
 
   var element, waypoints, source, target, elementDefinition, bounds;
 
@@ -59,7 +62,7 @@ DrdImporter.prototype.add = function(semantic) {
 
     element = elementFactory.createShape(elementDefinition);
 
-    canvas.addShape(element);
+    canvas.addShape(element, parent);
 
     eventBus.fire('drdElement.added', { element: element, di: di });
 

--- a/packages/dmn-js-drd/src/import/DrdTreeWalker.js
+++ b/packages/dmn-js-drd/src/import/DrdTreeWalker.js
@@ -16,9 +16,14 @@ export default function DRDTreeWalker(handler, options) {
 
   // list of elements to handle deferred to ensure
   // prerequisites are drawn
-  var deferred = [];
+  var deferred = [],
+      refToParent = new Map();
 
-  function visit(element) {
+  function mapRefToParent(ref, parent) {
+    refToParent.set(ref.href.replace(/^#/, ''), parent);
+  }
+
+  function visit(element, parentSemantic) {
 
     var gfx = element.gfx;
 
@@ -28,17 +33,17 @@ export default function DRDTreeWalker(handler, options) {
     }
 
     // call handler
-    return handler.element(element);
+    return handler.element(element, parentSemantic);
   }
 
   function visitRoot(element) {
     return handler.root(element);
   }
 
-  function visitIfDi(element) {
+  function visitIfDi(element, parentSemantic) {
 
     try {
-      var gfx = element.di && visit(element);
+      var gfx = element.di && visit(element, parentSemantic);
 
       return gfx;
     } catch (e) {
@@ -97,8 +102,16 @@ export default function DRDTreeWalker(handler, options) {
 
   function handleDrgElements(elements) {
     forEach(elements, function(element) {
-      visitIfDi(element);
+      if (is(element, 'dmn:DecisionService')) {
+        handleDecisionService(element);
+      } else if (is(element, 'dmn:Decision')) {
+        handleDecision(element);
+      } else {
+        visitIfDi(element);
+      }
+    });
 
+    forEach(elements, function(element) {
       handleRequirements(element);
     });
   }
@@ -140,6 +153,25 @@ export default function DRDTreeWalker(handler, options) {
           visitIfDi(requirement);
         });
       });
+    });
+  }
+
+  function handleDecisionService(element) {
+    visitIfDi(element);
+
+    forEach(element.get('encapsulatedDecision'), function(decisionRef) {
+      mapRefToParent(decisionRef, element);
+    });
+
+    forEach(element.get('outputDecision'), function(decisionRef) {
+      mapRefToParent(decisionRef, element);
+    });
+  }
+
+  function handleDecision(element) {
+    defer(function() {
+      var parent = refToParent.get(element.id);
+      visitIfDi(element, parent);
     });
   }
 

--- a/packages/dmn-js-drd/src/import/Importer.js
+++ b/packages/dmn-js-drd/src/import/Importer.js
@@ -26,8 +26,8 @@ export function importDRD(drd, definitions, done) {
         return importer.root(element);
       },
 
-      element: function(element, di) {
-        return importer.add(element, di);
+      element: function(element, parentSemantic) {
+        return importer.add(element, parentSemantic);
       },
 
       error: function(message, context) {

--- a/packages/dmn-js-drd/test/fixtures/dmn/decision-service.dmn
+++ b/packages/dmn-js-drd/test/fixtures/dmn/decision-service.dmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_dish" name="Dish" namespace="http://camunda.org/schema/1.0/dmn">
+  <decisionService id="DecisionService_0u44mqs" name="New Decision Service">
+    <variable id="InformationItem_1ln5h27" name="New Decision Service" />
+  </decisionService>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_04m4p5u">
+      <dmndi:DMNShape id="DMNShape_0ebc781" dmnElementRef="DecisionService_0u44mqs">
+        <dc:Bounds height="335" width="400" x="330" y="225" />
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="0" y="75" />
+          <di:waypoint x="200" y="75" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/fixtures/dmn/decision-service.dmn
+++ b/packages/dmn-js-drd/test/fixtures/dmn/decision-service.dmn
@@ -8,8 +8,8 @@
       <dmndi:DMNShape id="DMNShape_0ebc781" dmnElementRef="DecisionService_0u44mqs">
         <dc:Bounds height="335" width="400" x="330" y="225" />
         <dmndi:DMNDecisionServiceDividerLine>
-          <di:waypoint x="0" y="75" />
-          <di:waypoint x="200" y="75" />
+          <di:waypoint x="330" y="392.5" />
+          <di:waypoint x="730" y="392.5" />
         </dmndi:DMNDecisionServiceDividerLine>
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/packages/dmn-js-drd/test/fixtures/dmn/decision-service.dmn
+++ b/packages/dmn-js-drd/test/fixtures/dmn/decision-service.dmn
@@ -1,16 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_dish" name="Dish" namespace="http://camunda.org/schema/1.0/dmn">
-  <decisionService id="DecisionService_0u44mqs" name="New Decision Service">
-    <variable id="InformationItem_1ln5h27" name="New Decision Service" />
+  <decision id="OutputDecision" name="Output decision">
+    <variable name="Output decision" />
+  </decision>
+  <decision id="EncapsulatedDecision" name="Encapsulated decision">
+    <variable name="Encapsulated decision" />
+  </decision>
+  <decisionService id="DecisionService" name="Decision service">
+    <variable name="Decision service" />
+    <outputDecision href="#OutputDecision" />
+    <encapsulatedDecision href="#EncapsulatedDecision" />
   </decisionService>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram id="DMNDiagram_04m4p5u">
-      <dmndi:DMNShape id="DMNShape_0ebc781" dmnElementRef="DecisionService_0u44mqs">
+      <dmndi:DMNShape id="DMNShape_0ebc781" dmnElementRef="DecisionService">
         <dc:Bounds height="335" width="400" x="330" y="225" />
         <dmndi:DMNDecisionServiceDividerLine>
           <di:waypoint x="330" y="392.5" />
           <di:waypoint x="730" y="392.5" />
         </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="OutputDecisionDi" dmnElementRef="OutputDecision">
+        <dc:Bounds height="80" width="180" x="440" y="280" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="EncapsulatedDecisionDi" dmnElementRef="EncapsulatedDecision">
+        <dc:Bounds height="80" width="180" x="440" y="450" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>
   </dmndi:DMNDI>

--- a/packages/dmn-js-drd/test/spec/draw/DrdRendererSpec.js
+++ b/packages/dmn-js-drd/test/spec/draw/DrdRendererSpec.js
@@ -39,6 +39,11 @@ describe('draw - DrdRenderer', function() {
     return bootstrapViewer(xml).call(this);
   });
 
+  it('Decision Service', function() {
+    var xml = require('../../fixtures/dmn/decision-service.dmn');
+
+    return bootstrapViewer(xml).call(this);
+  });
 
   describe('colors', function() {
 

--- a/packages/dmn-js-drd/test/spec/features/auto-resize/DrdAutoResizeSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/auto-resize/DrdAutoResizeSpec.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai';
+
 import {
   bootstrapModeler,
   inject

--- a/packages/dmn-js-drd/test/spec/features/auto-resize/DrdAutoResizeSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/auto-resize/DrdAutoResizeSpec.js
@@ -1,0 +1,173 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import autoResizeModule from 'src/features/auto-resize';
+import coreModule from 'src/core';
+import modelingModule from 'src/features/modeling';
+
+
+describe('features/auto-resize', function() {
+
+  var diagramXML = require('./auto-resize.dmn');
+
+  var testModules = [
+    autoResizeModule,
+    coreModule,
+    modelingModule
+  ];
+
+  beforeEach(bootstrapModeler(diagramXML, { modules: testModules }));
+
+
+  describe('rules', function() {
+
+    it('should allow auto-resize on dmn:DecisionService with dmn:Decision',
+      inject(function(drdAutoResizeProvider, elementRegistry) {
+
+        // given
+        var decisionService = elementRegistry.get('DecisionService_1'),
+            decision = elementRegistry.get('Decision_Inside');
+
+        // when
+        var canResize = drdAutoResizeProvider.canResize([ decision ], decisionService);
+
+        // then
+        expect(canResize).to.be.true;
+      })
+    );
+
+
+    it('should NOT allow auto-resize on non dmn:DecisionService target',
+      inject(function(drdAutoResizeProvider, elementRegistry, canvas) {
+
+        // given
+        var root = canvas.getRootElement(),
+            decision = elementRegistry.get('Decision_Inside');
+
+        // when
+        var canResize = drdAutoResizeProvider.canResize([ decision ], root);
+
+        // then
+        expect(canResize).to.be.false;
+      })
+    );
+
+
+    it('should NOT allow auto-resize for non dmn:Decision elements',
+      inject(function(drdAutoResizeProvider, elementRegistry) {
+
+        // given
+        var decisionService = elementRegistry.get('DecisionService_1'),
+            inputData = elementRegistry.get('InputData_Outside');
+
+        // when
+        var canResize = drdAutoResizeProvider.canResize([ inputData ], decisionService);
+
+        // then
+        expect(canResize).to.be.false;
+      })
+    );
+
+  });
+
+
+  describe('behavior', function() {
+
+    it('should expand dmn:DecisionService when child moved near right edge',
+      inject(function(modeling, elementRegistry) {
+
+        // given
+        var decisionService = elementRegistry.get('DecisionService_1'),
+            decision = elementRegistry.get('Decision_Inside');
+
+        var oldWidth = decisionService.width;
+
+        // when
+        modeling.moveElements([ decision ], { x: 110, y: 0 }, decisionService);
+
+        // then
+        expect(decisionService.width).to.be.above(oldWidth);
+        expect(decisionService.x + decisionService.width)
+          .to.be.at.least(decision.x + decision.width);
+      })
+    );
+
+
+    it('should expand dmn:DecisionService when child moved near bottom edge',
+      inject(function(modeling, elementRegistry) {
+
+        // given
+        var decisionService = elementRegistry.get('DecisionService_1'),
+            decision = elementRegistry.get('Decision_Inside');
+
+        var oldHeight = decisionService.height;
+
+        // when
+        modeling.moveElements([ decision ], { x: 0, y: 180 }, decisionService);
+
+        // then
+        expect(decisionService.height).to.be.above(oldHeight);
+        expect(decisionService.y + decisionService.height)
+          .to.be.at.least(decision.y + decision.height);
+      })
+    );
+
+
+    it('should NOT expand dmn:DecisionService when child stays inside padding',
+      inject(function(modeling, elementRegistry) {
+
+        // given
+        var decisionService = elementRegistry.get('DecisionService_1'),
+            decision = elementRegistry.get('Decision_Inside');
+
+        var oldBounds = {
+          x: decisionService.x,
+          y: decisionService.y,
+          width: decisionService.width,
+          height: decisionService.height
+        };
+
+        // when
+        modeling.moveElements([ decision ], { x: 20, y: 20 }, decisionService);
+
+        // then
+        expect(decisionService.x).to.equal(oldBounds.x);
+        expect(decisionService.y).to.equal(oldBounds.y);
+        expect(decisionService.width).to.equal(oldBounds.width);
+        expect(decisionService.height).to.equal(oldBounds.height);
+      })
+    );
+
+
+    it('should undo auto-resize',
+      inject(function(modeling, elementRegistry, commandStack) {
+
+        // given
+        var decisionService = elementRegistry.get('DecisionService_1'),
+            decision = elementRegistry.get('Decision_Inside');
+
+        var oldBounds = {
+          x: decisionService.x,
+          y: decisionService.y,
+          width: decisionService.width,
+          height: decisionService.height
+        };
+
+        modeling.moveElements([ decision ], { x: 110, y: 0 }, decisionService);
+
+        // when
+        commandStack.undo();
+
+        // then
+        expect(decisionService.x).to.equal(oldBounds.x);
+        expect(decisionService.y).to.equal(oldBounds.y);
+        expect(decisionService.width).to.equal(oldBounds.width);
+        expect(decisionService.height).to.equal(oldBounds.height);
+      })
+    );
+
+  });
+
+});

--- a/packages/dmn-js-drd/test/spec/features/auto-resize/auto-resize.dmn
+++ b/packages/dmn-js-drd/test/spec/features/auto-resize/auto-resize.dmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="_definitions" name="Auto Resize Test" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Inside" name="Decision Inside">
+    <variable id="InformationItem_Inside" name="Decision Inside" />
+  </decision>
+  <inputData id="InputData_Outside" name="Input Data Outside">
+    <variable id="InformationItem_InputDataOutside" name="Input Data Outside" />
+  </inputData>
+  <decisionService id="DecisionService_1" name="Test Decision Service">
+    <variable id="InformationItem_DS1" name="Test Decision Service" />
+    <outputDecision href="#Decision_Inside" />
+  </decisionService>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1">
+      <dmndi:DMNShape id="DMNShape_DecisionService_1" dmnElementRef="DecisionService_1">
+        <dc:Bounds height="300" width="400" x="100" y="100" />
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="100" y="250" />
+          <di:waypoint x="500" y="250" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_Inside" dmnElementRef="Decision_Inside">
+        <dc:Bounds height="80" width="180" x="200" y="150" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_InputData_Outside" dmnElementRef="InputData_Outside">
+        <dc:Bounds height="45" width="125" x="700" y="300" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/modeling/DrdFactorySpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/DrdFactorySpec.js
@@ -167,6 +167,37 @@ describe('features/modeling - DrdFactory', function() {
         expect(point.$attrs).to.eql({});
       });
     }));
+
+
+    it('should create dmndi:DMNDecisionServiceDividerLine', inject(function(drdFactory) {
+
+      // given
+      var waypoints = [
+        { original: { x: 100, y: 200 }, x: 100, y: 200 },
+        { original: { x: 300, y: 200 }, x: 300, y: 200 }
+      ];
+
+      // when
+      var result = drdFactory.createDiDividerLine(waypoints);
+
+      // then
+      expect(result.$type).to.eql('dmndi:DMNDecisionServiceDividerLine');
+      expect(result).to.not.have.property('id');
+      expect(result).to.not.have.property('dmnElementRef');
+
+      var dividerWaypoints = result.waypoint;
+      expect(dividerWaypoints).to.exist;
+      expect(dividerWaypoints).to.have.lengthOf(2);
+
+      dividerWaypoints.forEach(function(point, index) {
+        expect(point.$type).to.eql('dc:Point');
+        expect(point.x).to.eql(waypoints[index].x);
+        expect(point.y).to.eql(waypoints[index].y);
+
+        // expect
+        expect(point.$attrs).to.eql({});
+      });
+    }));
   });
 
 });

--- a/packages/dmn-js-drd/test/spec/features/modeling/DrdUpdaterSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/DrdUpdaterSpec.js
@@ -625,8 +625,31 @@ describe('features/modeling - DrdUpdater', function() {
         }
       ));
 
-    });
+      it('should update divider line waypoints when DecisionService is resized', inject(
+        function(elementRegistry, modeling) {
 
+          // given
+          var decisionService = elementRegistry.get('DecisionService_1'),
+              decisionServiceBo = decisionService.businessObject;
+          var initialX = decisionService.x;
+          var initialY = decisionService.y;
+
+          // when
+          modeling.resizeShape(decisionService, { x: initialX, y: initialY, width: 500, height: 400 });
+
+          // then
+          var dividerLine = decisionServiceBo.di.decisionServiceDividerLine;
+          expect(dividerLine).to.exist;
+          expect(dividerLine.waypoint).to.have.lengthOf(2);
+          var expectedY = initialY + (400 / 2);
+          expect(dividerLine.waypoint[0].x).to.equal(initialX);
+          expect(dividerLine.waypoint[0].y).to.equal(expectedY);
+          expect(dividerLine.waypoint[1].x).to.equal(initialX + 500);
+          expect(dividerLine.waypoint[1].y).to.equal(expectedY);
+        }
+      ));
+
+    });
   });
 
 });

--- a/packages/dmn-js-drd/test/spec/features/modeling/DrdUpdaterSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/DrdUpdaterSpec.js
@@ -561,6 +561,74 @@ describe('features/modeling - DrdUpdater', function() {
     ));
 
   });
+
+
+  describe('DecisionService', function() {
+
+    var decisionServiceXML = require('./drd-updater-decision-service.dmn');
+
+    beforeEach(bootstrapModeler(decisionServiceXML, { modules: testModules }));
+
+
+    describe('update parent', function() {
+
+      it('should update parent when decision is moved into DecisionService', inject(
+        function(elementRegistry, modeling) {
+
+          // given
+          var decision = elementRegistry.get('Decision_Outside'),
+              decisionBo = decision.businessObject,
+              decisionService = elementRegistry.get('DecisionService_1'),
+              decisionServiceBo = decisionService.businessObject,
+              definitions = elementRegistry.get('Definitions_1'),
+              definitionsBo = definitions.businessObject;
+
+          // when
+          modeling.moveShape(decision, { x: 150, y: 280 }, decisionService);
+
+          // then
+          expect(decision.parent).to.equal(decisionService);
+          expect(decisionBo.$parent).to.equal(definitionsBo);
+          expect(definitionsBo.drgElement).to.include(decisionBo);
+
+          var outputDecisions = decisionServiceBo.get('outputDecision');
+          expect(outputDecisions.some(function(d) {
+            return d.href === '#Decision_Outside';
+          })).to.be.true;
+        }
+      ));
+
+
+      it('should update parent when decision is moved out of DecisionService', inject(
+        function(elementRegistry, modeling) {
+
+          // given
+          var decision = elementRegistry.get('Decision_InOutput'),
+              decisionBo = decision.businessObject,
+              decisionService = elementRegistry.get('DecisionService_1'),
+              decisionServiceBo = decisionService.businessObject,
+              definitions = elementRegistry.get('Definitions_1'),
+              definitionsBo = definitions.businessObject;
+
+          // when
+          modeling.moveShape(decision, { x: 300, y: -100 }, definitions);
+
+          // then
+          expect(decision.parent).to.equal(definitions);
+          expect(decisionBo.$parent).to.equal(definitionsBo);
+          expect(definitionsBo.drgElement).to.include(decisionBo);
+
+          var outputDecisions = decisionServiceBo.get('outputDecision');
+          expect(outputDecisions.some(function(d) {
+            return d.href === '#Decision_InOutput';
+          })).to.be.false;
+        }
+      ));
+
+    });
+
+  });
+
 });
 
 

--- a/packages/dmn-js-drd/test/spec/features/modeling/ElementFactorySpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/ElementFactorySpec.js
@@ -248,6 +248,58 @@ describe('features/modeling - create elements', function() {
         });
       }
     ));
+
+
+    it('should create a DecisionService', inject(
+      function(canvas, drdFactory, elementFactory, modeling) {
+
+        // given
+        var rootElement = canvas.getRootElement(),
+            businessObject = drdFactory.create('dmn:DecisionService'),
+            decisionService = elementFactory.createShape({
+              type: 'dmn:DecisionService',
+              businessObject: businessObject,
+              x: 100,
+              y: 100
+            });
+
+        // when
+        modeling.createShape(decisionService, { x: 100, y: 100 }, rootElement);
+
+        // then
+        expectShape(decisionService, {
+          type: 'dmn:DecisionService',
+          width: 320,
+          height: 320,
+          businessObject: businessObject
+        });
+      }
+    ));
+
+    it('should create a DecisionService with variable', inject(
+      function(canvas, drdFactory, elementFactory, modeling) {
+
+        // given
+        var rootElement = canvas.getRootElement(),
+            businessObject = drdFactory.create('dmn:DecisionService'),
+            decisionService = elementFactory.createShape({
+              type: 'dmn:DecisionService',
+              businessObject: businessObject,
+              x: 100,
+              y: 100
+            });
+
+        // when
+        modeling.createShape(decisionService, { x: 100, y: 100 }, rootElement);
+
+        // then
+        var variable = businessObject.variable;
+        expect(variable).to.exist;
+        expect(variable.$type).to.eql('dmn:InformationItem');
+        expect(variable.name).to.eql('New Decision Service');
+        expect(variable.$parent).to.equal(businessObject);
+      }
+    ));
   });
 
 

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/DecisionServiceBehaviorSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/DecisionServiceBehaviorSpec.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai';
+
 import {
   bootstrapModeler,
   inject

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/DecisionServiceBehaviorSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/DecisionServiceBehaviorSpec.js
@@ -1,0 +1,246 @@
+import {
+  bootstrapModeler,
+  inject
+} from 'test/helper';
+
+import CoreModule from 'src/core';
+import ModelingModule from 'src/features/modeling';
+
+import diagramXML from './decision-service-behavior.dmn';
+
+
+describe('DecisionServiceBehavior', function() {
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    modules: [
+      CoreModule,
+      ModelingModule
+    ]
+  }));
+
+
+  describe('_getDividerPosition', function() {
+
+    it('should calculate divider position at center of decision service', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decisionService = elementRegistry.get('DecisionService_1');
+        const expectedY = decisionService.y + (decisionService.height / 2);
+
+        // when
+        const dividerY = decisionServiceBehavior._getDividerPosition(decisionService);
+
+        // then
+        expect(dividerY).to.equal(expectedY);
+      })
+    );
+
+  });
+
+
+  describe('isOutputDecision', function() {
+
+    it('should identify decision in output section (top half)', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decision = elementRegistry.get('Decision_InOutput');
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+
+        // when
+        const result = decisionServiceBehavior.isOutputDecision(decision, decisionServiceBo);
+
+        // then
+        expect(result).to.be.true;
+      })
+    );
+
+
+    it('should identify decision in encapsulated section (bottom half)', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decision = elementRegistry.get('Decision_InEncapsulated');
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+
+        // when
+        const result = decisionServiceBehavior.isOutputDecision(decision, decisionServiceBo);
+
+        // then
+        expect(result).to.be.false;
+      })
+    );
+
+  });
+
+
+  describe('addDecisionToService', function() {
+
+    it('should add decision to appropriate section based on position', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decision = elementRegistry.get('Decision_Standalone');
+        const decisionBo = decision.businessObject;
+        const decisionServiceBo = elementRegistry.get('DecisionService_2').businessObject;
+        const definitions = elementRegistry.get('_definitions').businessObject;
+
+        // when
+        decisionServiceBehavior.addDecisionToService(decisionBo, decisionServiceBo, definitions);
+
+        // then
+        const outputDecisions = decisionServiceBo.get('outputDecision') || [];
+        expect(outputDecisions.some(ref => ref.href === '#Decision_Standalone')).to.be.true;
+        expect(decisionBo.$parent).to.equal(definitions);
+      })
+    );
+
+
+    it('should not add duplicate references', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decision = elementRegistry.get('Decision_InOutput');
+        const decisionBo = decision.businessObject;
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+        const definitions = elementRegistry.get('_definitions').businessObject;
+        const initialCount = (decisionServiceBo.get('outputDecision') || []).length;
+
+        // when
+        decisionServiceBehavior.addDecisionToService(decisionBo, decisionServiceBo, definitions);
+
+        // then
+        expect((decisionServiceBo.get('outputDecision') || []).length).to.equal(initialCount);
+      })
+    );
+
+  });
+
+
+  describe('removeDecisionFromService', function() {
+
+    it('should remove decision from service', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decisionBo = elementRegistry.get('Decision_InOutput').businessObject;
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+
+        // when
+        decisionServiceBehavior.removeDecisionFromService(decisionBo, decisionServiceBo);
+
+        // then
+        const outputDecisions = decisionServiceBo.get('outputDecision') || [];
+        expect(outputDecisions.some(ref => ref.href === '#Decision_InOutput')).to.be.false;
+      })
+    );
+
+  });
+
+
+
+
+
+  describe('updateInputsFromOutputDecisions', function() {
+
+    it('should automatically identify external input decisions', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+
+        // when
+        decisionServiceBehavior.updateInputsFromOutputDecisions(decisionServiceBo);
+
+        // then - Decision_1 should be identified as input decision
+        const inputDecisions = decisionServiceBo.get('inputDecision') || [];
+        expect(inputDecisions.some(ref => ref.href === '#Decision_1')).to.be.true;
+      })
+    );
+
+
+    it('should automatically identify required input data', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+
+        // when
+        decisionServiceBehavior.updateInputsFromOutputDecisions(decisionServiceBo);
+
+        // then - InputData_1 should be identified
+        const inputData = decisionServiceBo.get('inputData') || [];
+        expect(inputData.some(ref => ref.href === '#InputData_1')).to.be.true;
+      })
+    );
+
+
+    it('should not include encapsulated decisions as inputs', inject(
+      function(decisionServiceBehavior, elementRegistry, modeling) {
+
+        // given
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+        const outputDecision = elementRegistry.get('Decision_InOutput');
+        const encapsulatedDecision = elementRegistry.get('Decision_InEncapsulated');
+
+        // Create connection from output to encapsulated
+        modeling.connect(outputDecision, encapsulatedDecision);
+
+        // when
+        decisionServiceBehavior.updateInputsFromOutputDecisions(decisionServiceBo);
+
+        // then
+        const inputDecisions = decisionServiceBo.get('inputDecision') || [];
+        expect(inputDecisions.some(ref => ref.href === '#Decision_InEncapsulated')).to.be.false;
+      })
+    );
+
+  });
+
+
+
+
+
+  describe('removeElementFromAllServices', function() {
+
+    it('should remove element from all service collections', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const decisionServiceBo = elementRegistry.get('DecisionService_1').businessObject;
+        const definitions = elementRegistry.get('_definitions').businessObject;
+
+        // when
+        decisionServiceBehavior.removeElementFromAllServices('Decision_InOutput', definitions);
+
+        // then
+        const outputDecisions = decisionServiceBo.get('outputDecision') || [];
+        const inputDecisions = decisionServiceBo.get('inputDecision') || [];
+
+        expect(outputDecisions.some(ref => ref.href === '#Decision_InOutput')).to.be.false;
+        expect(inputDecisions.some(ref => ref.href === '#Decision_InOutput')).to.be.false;
+      })
+    );
+
+  });
+
+
+  describe('updateAllServices', function() {
+
+    it('should update all decision services in definitions', inject(
+      function(decisionServiceBehavior, elementRegistry) {
+
+        // given
+        const definitions = elementRegistry.get('_definitions').businessObject;
+
+        // when/then - should not throw
+        expect(function() {
+          decisionServiceBehavior.updateAllServices(definitions);
+        }).not.to.throw();
+      })
+    );
+
+  });
+
+});

--- a/packages/dmn-js-drd/test/spec/features/modeling/behavior/decision-service-behavior.dmn
+++ b/packages/dmn-js-drd/test/spec/features/modeling/behavior/decision-service-behavior.dmn
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="_definitions" name="Decision Service Behavior Test" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Outside" name="Decision Outside">
+    <variable id="InformationItem_Outside" name="Decision Outside" />
+  </decision>
+  <decision id="Decision_InOutput" name="Decision In Output">
+    <variable id="InformationItem_InOutput" name="Decision In Output" />
+    <informationRequirement id="InfoReq_1">
+      <requiredDecision href="#Decision_1" />
+    </informationRequirement>
+    <informationRequirement id="InfoReq_2">
+      <requiredInput href="#InputData_1" />
+    </informationRequirement>
+  </decision>
+  <decision id="Decision_InEncapsulated" name="Decision In Encapsulated">
+    <variable id="InformationItem_InEncapsulated" name="Decision In Encapsulated" />
+  </decision>
+  <inputData id="InputData_1" name="Input Data 1">
+    <variable id="InformationItem_InputData1" name="Input Data 1" />
+  </inputData>
+  <decision id="Decision_1" name="Decision_1">
+    <variable id="InformationItem_Decision" name="Decision_1" />
+  </decision>
+  <decision id="Decision_Standalone" name="Decision Standalone">
+    <variable id="InformationItem_Standalone" name="Decision Standalone" />
+  </decision>
+  <decisionService id="DecisionService_1" name="Test Decision Service">
+    <variable id="InformationItem_DS1" name="Test Decision Service" />
+    <outputDecision href="#Decision_InOutput" />
+    <encapsulatedDecision href="#Decision_InEncapsulated" />
+    <inputDecision href="#Decision_1"/>
+    <inputData href="#InputData_1" />
+  </decisionService>
+  <decisionService id="DecisionService_2" name="Second Decision Service">
+    <variable id="InformationItem_DS2" name="Second Decision Service" />
+  </decisionService>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1">
+      <dmndi:DMNShape id="DMNShape_Decision_Outside" dmnElementRef="Decision_Outside">
+        <dc:Bounds height="80" width="180" x="100" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_1" dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="400" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_Standalone" dmnElementRef="Decision_Standalone">
+        <dc:Bounds height="80" width="180" x="650" y="350" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_InputData_1" dmnElementRef="InputData_1">
+        <dc:Bounds height="45" width="125" x="450" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_DecisionService_1" dmnElementRef="DecisionService_1">
+        <dc:Bounds height="300" width="400" x="100" y="300" />
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="100" y="450" />
+          <di:waypoint x="500" y="450" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_InOutput" dmnElementRef="Decision_InOutput">
+        <dc:Bounds height="80" width="180" x="200" y="350" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_InEncapsulated" dmnElementRef="Decision_InEncapsulated">
+        <dc:Bounds height="80" width="180" x="200" y="500" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_DecisionService_2" dmnElementRef="DecisionService_2">
+        <dc:Bounds height="200" width="300" x="600" y="300" />
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="600" y="400" />
+          <di:waypoint x="900" y="400" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_InfoReq_1" dmnElementRef="InfoReq_1">
+        <di:waypoint x="490" y="180" />
+        <di:waypoint x="290" y="350" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_InfoReq_2" dmnElementRef="InfoReq_2">
+        <di:waypoint x="512" y="145" />
+        <di:waypoint x="290" y="350" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/modeling/drd-updater-decision-service.dmn
+++ b/packages/dmn-js-drd/test/spec/features/modeling/drd-updater-decision-service.dmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Definitions_1" name="DRD with DecisionService" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Outside" name="Decision Outside" />
+  <decision id="Decision_InOutput" name="Decision In Output">
+    <variable id="InformationItem_1" name="Decision In Output" />
+  </decision>
+  <decision id="Decision_InEncapsulated" name="Decision In Encapsulated">
+    <variable id="InformationItem_2" name="Decision In Encapsulated" />
+  </decision>
+  <decision id="Decision_Standalone" name="Decision Standalone" />
+  <decisionService id="DecisionService_1" name="Test Decision Service">
+    <variable id="InformationItem_3" name="Test Decision Service" />
+    <outputDecision href="#Decision_InOutput" />
+    <encapsulatedDecision href="#Decision_InEncapsulated" />
+  </decisionService>
+  <decisionService id="DecisionService_2" name="Second Decision Service">
+    <variable id="InformationItem_4" name="Second Decision Service" />
+  </decisionService>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1">
+      <dmndi:DMNShape id="DMNShape_Decision_Outside" dmnElementRef="Decision_Outside">
+        <dc:Bounds height="80" width="180" x="100" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_Standalone" dmnElementRef="Decision_Standalone">
+        <dc:Bounds height="80" width="180" x="400" y="100" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_DecisionService_1" dmnElementRef="DecisionService_1">
+        <dc:Bounds height="300" width="400" x="100" y="300" />
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="100" y="450" />
+          <di:waypoint x="500" y="450" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>br
+      <dmndi:DMNShape id="DMNShape_Decision_InOutput" dmnElementRef="Decision_InOutput">
+        <dc:Bounds height="80" width="180" x="200" y="350" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_Decision_InEncapsulated" dmnElementRef="Decision_InEncapsulated">
+        <dc:Bounds height="80" width="180" x="200" y="500" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_DecisionService_2" dmnElementRef="DecisionService_2">
+        <dc:Bounds height="200" width="300" x="600" y="300" />
+        <dmndi:DMNDecisionServiceDividerLine>
+          <di:waypoint x="600" y="400" />
+          <di:waypoint x="900" y="400" />
+        </dmndi:DMNDecisionServiceDividerLine>
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/packages/dmn-js-drd/test/spec/features/modeling/drd-updater-decision-service.dmn
+++ b/packages/dmn-js-drd/test/spec/features/modeling/drd-updater-decision-service.dmn
@@ -30,7 +30,7 @@
           <di:waypoint x="100" y="450" />
           <di:waypoint x="500" y="450" />
         </dmndi:DMNDecisionServiceDividerLine>
-      </dmndi:DMNShape>br
+      </dmndi:DMNShape>
       <dmndi:DMNShape id="DMNShape_Decision_InOutput" dmnElementRef="Decision_InOutput">
         <dc:Bounds height="80" width="180" x="200" y="350" />
       </dmndi:DMNShape>

--- a/packages/dmn-js-drd/test/spec/features/palette/PaletteProviderSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/palette/PaletteProviderSpec.js
@@ -31,10 +31,10 @@ describe('features/palette', function() {
 
     // when
     var paletteElement = domQuery('.djs-palette', canvas._container);
-    var entries = domQueryAll('.entry', paletteElement);
+    var entries = domQueryAll('.entry', paletteElement)
 
     // then
-    expect(entries.length).to.equal(6);
+    expect(entries.length).to.equal(7);
   }));
 
 

--- a/packages/dmn-js-drd/test/spec/features/palette/PaletteProviderSpec.js
+++ b/packages/dmn-js-drd/test/spec/features/palette/PaletteProviderSpec.js
@@ -31,7 +31,7 @@ describe('features/palette', function() {
 
     // when
     var paletteElement = domQuery('.djs-palette', canvas._container);
-    var entries = domQueryAll('.entry', paletteElement)
+    var entries = domQueryAll('.entry', paletteElement);
 
     // then
     expect(entries.length).to.equal(7);

--- a/packages/dmn-js-drd/test/spec/import/ImportSpec.js
+++ b/packages/dmn-js-drd/test/spec/import/ImportSpec.js
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 import {
   bootstrapModeler,
   getDrdJS,
-  getDmnJS
+  getDmnJS,
+  inject
 } from 'test/TestHelper';
 
 import exampleXML from '../../fixtures/dmn/di-1-3.dmn';
 import multipleDecisionsXML from '../../fixtures/dmn/multiple-decisions.dmn';
+import decisionServiceXML from '../../fixtures/dmn/decision-service.dmn';
 
 import {
   pick
@@ -168,7 +170,6 @@ describe('DRD - Import', function() {
   });
 
 
-
   describe('cropping', function() {
 
     beforeEach(bootstrapModeler(multipleDecisionsXML));
@@ -213,6 +214,25 @@ describe('DRD - Import', function() {
 
     });
 
+  });
+
+
+  describe('decision service', function() {
+
+    beforeEach(bootstrapModeler(decisionServiceXML));
+
+
+    it('should set decision sevice as parent of encapsulated and output decisions', inject(function(elementRegistry) {
+
+      // given
+      const decisionService = elementRegistry.get('DecisionService');
+      const encapsulatedDecision = elementRegistry.get('EncapsulatedDecision');
+      const outputDecision = elementRegistry.get('OutputDecision');
+
+      // then
+      expect(encapsulatedDecision.parent).to.equal(decisionService);
+      expect(outputDecision.parent).to.equal(decisionService);
+    }));
   });
 
 });

--- a/packages/dmn-js-shared/src/features/modeling/behavior/NameChangeBehavior.js
+++ b/packages/dmn-js-shared/src/features/modeling/behavior/NameChangeBehavior.js
@@ -39,7 +39,7 @@ export default class NameChangeBehavior extends CommandInterceptor {
       return;
     }
 
-    if (!(is(element, 'dmn:Decision') || is(element, 'dmn:BusinessKnowledgeModel'))) {
+    if (!(is(element, 'dmn:Decision') || is(element, 'dmn:BusinessKnowledgeModel') || is(element, 'dmn:DecisionService'))) {
       return;
     }
 


### PR DESCRIPTION
### Proposed Changes

This PR started from #983 (Decision Service support, by @Abiola-Farounbi), rebased onto current `develop` as a single squashed commit, on top of which it fixes two bugs found while reviewing that PR:

* `DrdRules` allowed a `Decision -> DecisionService` connection to also produce a `dmn:KnowledgeRequirement`. This reversed the direction used everywhere else for knowledge requirements (provider -> consumer, e.g. `BusinessKnowledgeModel -> Decision`), so `CreateConnectionBehavior` wrote `requiredDecision` instead of `requiredKnowledge`, and the requirement was parented under the `DecisionService` instead of the requiring `Decision`. The correct rule (`DecisionService -> Decision`/`BusinessKnowledgeModel`) already existed in the file, so the reversed one is simply removed.
* Replacing a decision's logic (e.g. via the morph menu, literal expression <-> empty) left decision service output/encapsulated references stale. `DecisionServiceBehavior` now listens to `shape.replace` itself and keeps those references consistent.

All of #983's work plus both fixes above now live in one commit (`Co-authored-by` trailers preserve everyone who contributed). Rebasing onto current `develop` also drops an unintended side effect of #983 having been forked from an old point in `develop`'s history: it no longer reverts the `Viewer.js` SVG-export fix and `dmn-js-literal-expression` fixes that landed on `develop` since.

This should ultimately land as part of #983 rather than merge on its own.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

Related to https://github.com/bpmn-io/dmn-js/pull/983
Related to https://github.com/bpmn-io/dmn-js/issues/957